### PR TITLE
feat: add Harbor integration for Terminal-Bench 2.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,7 @@ dist/
 .env
 *.log
 .conversations/
+
+# tbranch artifact
+jobs
+__pycache__

--- a/harbor_agent.py
+++ b/harbor_agent.py
@@ -1,0 +1,223 @@
+from __future__ import annotations
+
+import json
+import os
+import shlex
+from pathlib import Path
+from typing import Any
+
+from harbor.agents.installed.base import BaseInstalledAgent, ExecInput
+from harbor.models.agent.context import AgentContext
+from harbor.models.trajectories import (
+    Agent,
+    Step,
+    ToolCall,
+    Observation,
+    ObservationResult,
+    Metrics,
+    FinalMetrics,
+    Trajectory,
+)
+
+
+class CodeEditingAgent(BaseInstalledAgent):
+    SUPPORTS_ATIF: bool = True
+
+    @staticmethod
+    def name() -> str:
+        return "code-editing-agent"
+
+    @property
+    def _install_agent_template_path(self) -> Path:
+        return Path(__file__).parent / "install-agent.sh.j2"
+
+    def _get_log_file(self) -> Path | None:
+        log_file = self.logs_dir / "agent" / "output.jsonl"
+        if log_file.exists():
+            return log_file
+        return None
+
+    def _convert_events_to_trajectory(self, log_file: Path) -> Trajectory | None:
+        events: list[dict[str, Any]] = []
+        with open(log_file) as f:
+            for line in f:
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    events.append(json.loads(line))
+                except json.JSONDecodeError:
+                    continue
+
+        if not events:
+            return None
+
+        session_id = events[0].get("sessionId", "unknown")
+        steps: list[Step] = []
+        step_id = 0
+
+        for event in events:
+            event_type = event.get("type")
+            timestamp = event.get("timestamp")
+            message = event.get("message", {})
+
+            if event_type == "user":
+                step_id += 1
+                content = message.get("content", "")
+                text_content = (
+                    str(content) if isinstance(content, list) else str(content)
+                )
+                steps.append(
+                    Step(
+                        step_id=step_id,
+                        timestamp=timestamp,
+                        source="user",
+                        message=text_content,
+                    )
+                )
+
+            elif event_type == "assistant":
+                step_id += 1
+                content = message.get("content", "")
+                model_name = message.get("model")
+                usage = message.get("usage", {})
+
+                tool_calls: list[ToolCall] = []
+                text_content = ""
+
+                if isinstance(content, list):
+                    for block in content:
+                        if isinstance(block, dict) and block.get("type") == "tool_use":
+                            tool_calls.append(
+                                ToolCall(
+                                    tool_call_id=block.get("id", ""),
+                                    function_name=block.get("name", ""),
+                                    arguments=block.get("input", {}),
+                                )
+                            )
+                        else:
+                            text_content += str(block)
+                else:
+                    text_content = str(content)
+
+                metrics = None
+                if usage:
+                    metrics = Metrics(
+                        prompt_tokens=usage.get("input_tokens"),
+                        completion_tokens=usage.get("output_tokens"),
+                        cached_tokens=usage.get("cache_read_input_tokens"),
+                    )
+
+                observation = None
+                tool_result = event.get("toolUseResult")
+                if tool_result and tool_calls:
+                    observation = Observation(
+                        results=[
+                            ObservationResult(
+                                source_call_id=tool_calls[0].tool_call_id,
+                                content=tool_result.get("stdout", ""),
+                            )
+                        ]
+                    )
+
+                steps.append(
+                    Step(
+                        step_id=step_id,
+                        timestamp=timestamp,
+                        source="agent",
+                        message=text_content or "Tool execution",
+                        model_name=model_name or self.model_name,
+                        tool_calls=tool_calls if tool_calls else None,
+                        observation=observation,
+                        metrics=metrics,
+                    )
+                )
+
+        if not steps:
+            return None
+
+        total_prompt = sum(
+            s.metrics.prompt_tokens
+            for s in steps
+            if s.metrics and s.metrics.prompt_tokens
+        )
+        total_completion = sum(
+            s.metrics.completion_tokens
+            for s in steps
+            if s.metrics and s.metrics.completion_tokens
+        )
+        total_cached = sum(
+            s.metrics.cached_tokens
+            for s in steps
+            if s.metrics and s.metrics.cached_tokens
+        )
+
+        return Trajectory(
+            schema_version="ATIF-v1.4",
+            session_id=session_id,
+            agent=Agent(
+                name=self.name(),
+                version=self.version(),
+                model_name=self.model_name,
+            ),
+            steps=steps,
+            final_metrics=FinalMetrics(
+                total_prompt_tokens=total_prompt or None,
+                total_completion_tokens=total_completion or None,
+                total_cached_tokens=total_cached or None,
+                total_steps=len(steps),
+            ),
+        )
+
+    def populate_context_post_run(self, context: AgentContext) -> None:
+        log_file = self._get_log_file()
+        if not log_file:
+            print("No output log file found")
+            return
+
+        try:
+            trajectory = self._convert_events_to_trajectory(log_file)
+        except Exception as e:
+            print(f"Failed to convert events to trajectory: {e}")
+            return
+
+        if not trajectory:
+            print("Failed to convert events to trajectory")
+            return
+
+        trajectory_path = self.logs_dir / "trajectory.json"
+        try:
+            with open(trajectory_path, "w") as f:
+                json.dump(trajectory.to_json_dict(), f, indent=2)
+            print(f"Wrote trajectory to {trajectory_path}")
+        except OSError as e:
+            print(f"Failed to write trajectory: {e}")
+
+        if trajectory.final_metrics:
+            context.n_input_tokens = trajectory.final_metrics.total_prompt_tokens or 0
+            context.n_output_tokens = (
+                trajectory.final_metrics.total_completion_tokens or 0
+            )
+            context.n_cache_tokens = trajectory.final_metrics.total_cached_tokens or 0
+
+    def create_run_agent_commands(self, instruction: str) -> list[ExecInput]:
+        escaped_instruction = shlex.quote(instruction)
+
+        env = {
+            "FRIENDLI_TOKEN": os.environ.get("FRIENDLI_TOKEN", ""),
+        }
+        env = {k: v for k, v in env.items() if v}
+
+        return [
+            ExecInput(
+                command="mkdir -p /logs/agent",
+            ),
+            ExecInput(
+                command=(
+                    f"export BUN_INSTALL=$HOME/.bun && export PATH=$BUN_INSTALL/bin:$PATH && "
+                    f"cd /app && bun run headless -p {escaped_instruction} "
+                    f"2>&1 | tee /logs/agent/output.jsonl"
+                ),
+                env=env,
+            ),
+        ]

--- a/install-agent.sh.j2
+++ b/install-agent.sh.j2
@@ -1,0 +1,19 @@
+#!/bin/bash
+set -e
+
+echo "Installing dependencies..."
+apt-get update -qq
+apt-get install -y -qq curl git unzip ca-certificates
+
+echo "Installing bun..."
+curl -fsSL https://bun.sh/install | bash
+export BUN_INSTALL="$HOME/.bun"
+export PATH="$BUN_INSTALL/bin:$PATH"
+
+echo "Cloning code-editing-agent..."
+git clone --depth 1 https://github.com/minpeter/agent.git /app
+cd /app
+bun install
+
+echo "code-editing-agent installed successfully"
+bun --version

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   },
   "scripts": {
     "start": "bun run src/index.ts",
+    "headless": "bun run src/headless.ts",
     "build": "tsc",
     "dev": "bun run --watch src/index.ts",
     "check": "ultracite check",

--- a/src/headless.ts
+++ b/src/headless.ts
@@ -1,0 +1,213 @@
+#!/usr/bin/env bun
+
+/**
+ * Headless mode entry point for Harbor integration.
+ * Usage: bun run src/headless.ts -p "instruction"
+ */
+
+import type { ToolApprovalResponse } from "ai";
+import { agentManager } from "./agent";
+import { MessageHistory } from "./context/message-history";
+
+interface TrajectoryEvent {
+  timestamp: string;
+  type: "user" | "assistant" | "tool_call" | "tool_result" | "error";
+  sessionId: string;
+  message?: {
+    role: string;
+    content: string | unknown[];
+    model?: string;
+    usage?: {
+      input_tokens: number;
+      output_tokens: number;
+      cache_read_input_tokens?: number;
+    };
+  };
+  toolUseResult?: {
+    stdout?: string;
+    stderr?: string;
+    exitCode?: number;
+  };
+  error?: string;
+}
+
+const sessionId = `session-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+const startTime = Date.now();
+
+const emitEvent = (event: TrajectoryEvent): void => {
+  console.log(JSON.stringify(event));
+};
+
+const parseArgs = (): { prompt: string } => {
+  const args = process.argv.slice(2);
+  let prompt = "";
+
+  for (let i = 0; i < args.length; i++) {
+    if (args[i] === "-p" || args[i] === "--prompt") {
+      prompt = args[i + 1] || "";
+      i++;
+    }
+  }
+
+  if (!prompt) {
+    console.error("Usage: bun run src/headless.ts -p <prompt>");
+    process.exit(1);
+  }
+
+  return { prompt };
+};
+
+const autoApproveAll = (
+  requests: Array<{
+    approvalId: string;
+    toolCall: { toolName: string };
+  }>
+): ToolApprovalResponse[] => {
+  return requests.map((req) => ({
+    type: "tool-approval-response" as const,
+    approvalId: req.approvalId,
+    approved: true,
+    reason: "Auto-approved in headless mode",
+  }));
+};
+
+interface ApprovalRequest {
+  type: "tool-approval-request";
+  approvalId: string;
+  toolCall: {
+    toolName: string;
+    toolCallId: string;
+    input: unknown;
+  };
+}
+
+const processAgentResponse = async (
+  messageHistory: MessageHistory
+): Promise<void> => {
+  const stream = await agentManager.stream(messageHistory.toModelMessages());
+  const approvalRequests: ApprovalRequest[] = [];
+
+  let currentText = "";
+
+  for await (const part of stream.fullStream) {
+    switch (part.type) {
+      case "text-delta":
+        currentText += part.text;
+        break;
+      case "tool-call":
+        emitEvent({
+          timestamp: new Date().toISOString(),
+          type: "assistant",
+          sessionId,
+          message: {
+            role: "assistant",
+            content: [
+              {
+                type: "tool_use",
+                id: part.toolCallId,
+                name: part.toolName,
+                input: part.input,
+              },
+            ],
+            model: agentManager.getModelId(),
+          },
+        });
+        break;
+      case "tool-result":
+        emitEvent({
+          timestamp: new Date().toISOString(),
+          type: "user",
+          sessionId,
+          message: {
+            role: "user",
+            content: [
+              {
+                type: "tool_result",
+                tool_use_id: part.toolCallId,
+                content: String(part.output),
+              },
+            ],
+          },
+          toolUseResult: {
+            stdout:
+              typeof part.output === "object" &&
+              part.output !== null &&
+              "output" in part.output
+                ? String((part.output as { output: unknown }).output)
+                : String(part.output),
+            exitCode:
+              typeof part.output === "object" &&
+              part.output !== null &&
+              "exitCode" in part.output
+                ? Number((part.output as { exitCode: unknown }).exitCode)
+                : 0,
+          },
+        });
+        break;
+      case "tool-approval-request":
+        approvalRequests.push(part);
+        break;
+      default:
+        break;
+    }
+  }
+
+  const response = await stream.response;
+  messageHistory.addModelMessages(response.messages);
+
+  if (currentText.trim()) {
+    emitEvent({
+      timestamp: new Date().toISOString(),
+      type: "assistant",
+      sessionId,
+      message: {
+        role: "assistant",
+        content: currentText,
+        model: agentManager.getModelId(),
+      },
+    });
+  }
+
+  if (approvalRequests.length > 0) {
+    const approvals = autoApproveAll(approvalRequests);
+    messageHistory.addToolApprovalResponses(approvals);
+    await processAgentResponse(messageHistory);
+  }
+};
+
+const run = async (): Promise<void> => {
+  const { prompt } = parseArgs();
+  const messageHistory = new MessageHistory();
+
+  emitEvent({
+    timestamp: new Date().toISOString(),
+    type: "user",
+    sessionId,
+    message: {
+      role: "user",
+      content: prompt,
+    },
+  });
+
+  messageHistory.addUserMessage(prompt);
+
+  try {
+    await processAgentResponse(messageHistory);
+  } catch (error) {
+    emitEvent({
+      timestamp: new Date().toISOString(),
+      type: "error",
+      sessionId,
+      error: error instanceof Error ? error.message : String(error),
+    });
+    process.exit(1);
+  }
+
+  const elapsed = ((Date.now() - startTime) / 1000).toFixed(2);
+  console.error(`[headless] Completed in ${elapsed}s`);
+};
+
+run().catch((error: unknown) => {
+  console.error("Fatal error:", error);
+  process.exit(1);
+});

--- a/src/interaction/stream-renderer.ts
+++ b/src/interaction/stream-renderer.ts
@@ -1,7 +1,7 @@
 import type { Writable } from "node:stream";
 import type { TextStreamPart, ToolSet } from "ai";
-import { colorize, colors } from "./colors";
 import { env } from "../env";
+import { colorize, colors } from "./colors";
 
 export interface StreamRenderOptions {
   output?: Writable;


### PR DESCRIPTION
## Summary
- Add headless mode for non-interactive agent execution
- Add Harbor InstalledAgent wrapper with ATIF trajectory support
- Enable Terminal-Bench 2.0 evaluation

## Changes
- `src/headless.ts`: Headless mode entry point that outputs JSONL trajectory
- `harbor_agent.py`: Python wrapper implementing Harbor's BaseInstalledAgent interface
- `install-agent.sh.j2`: Docker container installation script
- `package.json`: Added `headless` script

## Usage
```bash
harbor run -d terminal-bench@2.0 --agent-import-path harbor_agent:CodeEditingAgent -n 1
```