### PR TITLE
fix: render write_file output as read-style content block

### DIFF
--- a/packages/cea/src/interaction/pi-tui-stream-renderer.ts
+++ b/packages/cea/src/interaction/pi-tui-stream-renderer.ts
@@ -1428,8 +1428,17 @@ class ToolCallView extends Container {
       return false;
     }
 
+    const bestInput = this.resolveBestInput();
     const path = this.resolveInputStringField("path") ?? "(unknown)";
+    const fileContent = extractStringField(bestInput, "content");
     const header = buildPrettyHeader("Write", path);
+
+    if (fileContent !== null) {
+      this.setPrettyBlock(header, fileContent, {
+        useBackground: true,
+      });
+      return true;
+    }
 
     if (this.output === undefined) {
       this.setPrettyBlock(header, renderPendingOutput(), {


### PR DESCRIPTION
## Summary
- Render `write_file` tool output using the same read-style content block view when streamed `content` is available.
- Keep the full file content visible in the tool block and avoid showing write result metadata in that view.
- Add regression coverage for streamed `write_file` content to ensure no preview truncation marker is shown.

## Verification
- `bun test packages/cea/src/interaction/pi-tui-stream-renderer.test.ts`
- `bun run typecheck`
- `bun run build`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Render streamed write_file content as a read-style block so users can see the full file without preview truncation. Hide write result metadata in this view and add a regression test for streamed content.

<sup>Written for commit ea3ace515cc1fdc13aeda4af3f3bd7766152b7da. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

