### PR TITLE
fix(safety): add path traversal and symlink protection to write operations

### DIFF
--- a/packages/cea/src/tools/modify/delete-file.test.ts
+++ b/packages/cea/src/tools/modify/delete-file.test.ts
@@ -3,7 +3,9 @@ import {
   existsSync,
   mkdirSync,
   mkdtempSync,
+  readFileSync,
   rmSync,
+  symlinkSync,
   writeFileSync,
 } from "node:fs";
 import { tmpdir } from "node:os";
@@ -28,7 +30,7 @@ describe("executeDeleteFile", () => {
       const testFile = join(tempDir, "to-delete.txt");
       writeFileSync(testFile, "content to delete");
 
-      const result = await executeDeleteFile({ path: testFile });
+      const result = await executeDeleteFile({ path: testFile }, { rootDir: tempDir });
 
       expect(result).toContain("OK - deleted file: to-delete.txt");
       expect(result).toContain(`path: ${testFile}`);
@@ -42,7 +44,7 @@ describe("executeDeleteFile", () => {
       const content = "12345";
       writeFileSync(testFile, content);
 
-      const result = await executeDeleteFile({ path: testFile });
+      const result = await executeDeleteFile({ path: testFile }, { rootDir: tempDir });
 
       expect(result).toContain("bytes: 5");
     });
@@ -53,9 +55,9 @@ describe("executeDeleteFile", () => {
       const testDir = join(tempDir, "dir-no-recursive");
       mkdirSync(testDir);
 
-      await expect(executeDeleteFile({ path: testDir })).rejects.toThrow(
-        "recursive: true"
-      );
+      await expect(
+        executeDeleteFile({ path: testDir }, { rootDir: tempDir })
+      ).rejects.toThrow("recursive: true");
 
       expect(existsSync(testDir)).toBe(true);
     });
@@ -64,10 +66,10 @@ describe("executeDeleteFile", () => {
       const testDir = join(tempDir, "empty-dir");
       mkdirSync(testDir);
 
-      const result = await executeDeleteFile({
-        path: testDir,
-        recursive: true,
-      });
+      const result = await executeDeleteFile(
+        { path: testDir, recursive: true },
+        { rootDir: tempDir }
+      );
 
       expect(result).toContain("OK - deleted directory: empty-dir");
       expect(result).toContain(`path: ${testDir}`);
@@ -83,10 +85,10 @@ describe("executeDeleteFile", () => {
       mkdirSync(join(testDir, "subdir"));
       writeFileSync(join(testDir, "subdir", "nested.txt"), "nested");
 
-      const result = await executeDeleteFile({
-        path: testDir,
-        recursive: true,
-      });
+      const result = await executeDeleteFile(
+        { path: testDir, recursive: true },
+        { rootDir: tempDir }
+      );
 
       expect(result).toContain("OK - deleted directory: non-empty-dir");
       expect(existsSync(testDir)).toBe(false);
@@ -97,16 +99,16 @@ describe("executeDeleteFile", () => {
     it("throws error for non-existent file by default", async () => {
       const nonExistent = join(tempDir, "does-not-exist.txt");
 
-      await expect(executeDeleteFile({ path: nonExistent })).rejects.toThrow();
+      await expect(executeDeleteFile({ path: nonExistent }, { rootDir: tempDir })).rejects.toThrow();
     });
 
     it("returns skip message when ignore_missing is true", async () => {
       const nonExistent = join(tempDir, "also-does-not-exist.txt");
 
-      const result = await executeDeleteFile({
-        path: nonExistent,
-        ignore_missing: true,
-      });
+      const result = await executeDeleteFile(
+        { path: nonExistent, ignore_missing: true },
+        { rootDir: tempDir }
+      );
 
       expect(result).toContain("SKIPPED");
       expect(result).toContain("file does not exist");
@@ -119,7 +121,7 @@ describe("executeDeleteFile", () => {
       const testFile = join(tempDir, "file with spaces.txt");
       writeFileSync(testFile, "content");
 
-      const result = await executeDeleteFile({ path: testFile });
+      const result = await executeDeleteFile({ path: testFile }, { rootDir: tempDir });
 
       expect(result).toContain("OK - deleted file: file with spaces.txt");
       expect(existsSync(testFile)).toBe(false);
@@ -129,11 +131,70 @@ describe("executeDeleteFile", () => {
       const testFile = join(tempDir, "empty-file.txt");
       writeFileSync(testFile, "");
 
-      const result = await executeDeleteFile({ path: testFile });
+      const result = await executeDeleteFile({ path: testFile }, { rootDir: tempDir });
 
       expect(result).toContain("OK - deleted file: empty-file.txt");
       expect(result).toContain("bytes: 0");
       expect(existsSync(testFile)).toBe(false);
+    });
+  });
+
+  describe("file safety (C-1, C-2)", () => {
+    it("C-1: blocks path traversal via .. segments", async () => {
+      const traversalPath = join(tempDir, "..", "..", "etc", "passwd");
+      await expect(
+        executeDeleteFile({ path: traversalPath }, { rootDir: tempDir })
+      ).rejects.toThrow(/[Pp]ath traversal blocked/);
+    });
+
+    it("C-1: blocks absolute paths outside project root", async () => {
+      await expect(
+        executeDeleteFile({ path: "/tmp/outside-project.txt" }, { rootDir: tempDir })
+      ).rejects.toThrow(/[Pp]ath traversal blocked|outside/);
+    });
+
+    it("C-2: blocks deletion of symlinks", async () => {
+      const realFile = join(tempDir, "real-delete-target.txt");
+      writeFileSync(realFile, "real content");
+      const symlinkPath = join(tempDir, "symlink-to-delete.txt");
+      symlinkSync(realFile, symlinkPath);
+
+      await expect(
+        executeDeleteFile({ path: symlinkPath }, { rootDir: tempDir })
+      ).rejects.toThrow(/symlink/i);
+
+      // Both the symlink and the real file should still exist
+      expect(existsSync(symlinkPath)).toBe(true);
+      expect(existsSync(realFile)).toBe(true);
+      expect(readFileSync(realFile, "utf-8")).toBe("real content");
+    });
+
+    it("C-2: blocks deletion of symlinks pointing outside root", async () => {
+      const outsideDir = mkdtempSync(join(tmpdir(), "outside-delete-"));
+      const outsideFile = join(outsideDir, "secret.txt");
+      writeFileSync(outsideFile, "secret data");
+      const symlinkPath = join(tempDir, "escape-delete-link.txt");
+      symlinkSync(outsideFile, symlinkPath);
+
+      try {
+        await expect(
+          executeDeleteFile({ path: symlinkPath }, { rootDir: tempDir })
+        ).rejects.toThrow(/symlink/i);
+        expect(existsSync(outsideFile)).toBe(true);
+        expect(readFileSync(outsideFile, "utf-8")).toBe("secret data");
+      } finally {
+        rmSync(outsideDir, { recursive: true });
+      }
+    });
+
+    it("allows deletion within project root (normal operation)", async () => {
+      const safeFile = join(tempDir, "safe-to-delete.txt");
+      writeFileSync(safeFile, "deletable content");
+
+      const result = await executeDeleteFile({ path: safeFile }, { rootDir: tempDir });
+
+      expect(result).toContain("OK - deleted file: safe-to-delete.txt");
+      expect(existsSync(safeFile)).toBe(false);
     });
   });
 });

--- a/packages/cea/src/tools/modify/delete-file.ts
+++ b/packages/cea/src/tools/modify/delete-file.ts
@@ -1,7 +1,8 @@
-import { rm, stat } from "node:fs/promises";
+import { lstat, rm } from "node:fs/promises";
 import { basename } from "node:path";
 import { tool } from "ai";
 import { z } from "zod";
+import { assertWriteSafety } from "../utils/safety-utils";
 import DELETE_FILE_DESCRIPTION from "./delete-file.txt";
 
 const inputSchema = z.object({
@@ -20,14 +21,23 @@ const inputSchema = z.object({
 
 export type DeleteFileInput = z.input<typeof inputSchema>;
 
-export async function executeDeleteFile({
-  path,
-  recursive = false,
-  ignore_missing = false,
-}: DeleteFileInput): Promise<string> {
-  let stats: Awaited<ReturnType<typeof stat>>;
+export interface DeleteFileOptions {
+  /** Override project root for safety checks (defaults to process.cwd()). */
+  rootDir?: string;
+}
+
+export async function executeDeleteFile(
+  { path, recursive = false, ignore_missing = false }: DeleteFileInput,
+  options?: DeleteFileOptions
+): Promise<string> {
+  // C-1 + C-2: Path traversal and symlink safety checks
+  const safePath = await assertWriteSafety(path, options?.rootDir);
+
+  // C-2: Use lstat (not stat) — lstat does NOT follow symlinks,
+  // so we see the symlink entry itself rather than its target.
+  let stats: Awaited<ReturnType<typeof lstat>>;
   try {
-    stats = await stat(path);
+    stats = await lstat(safePath);
   } catch (error) {
     if (
       ignore_missing &&
@@ -38,6 +48,14 @@ export async function executeDeleteFile({
       return `SKIPPED - file does not exist: ${path}`;
     }
     throw error;
+  }
+
+  // Reject symlink deletion — force explicit resolution
+  if (stats.isSymbolicLink()) {
+    throw new Error(
+      `Refusing to delete symlink: '${path}'. ` +
+        "Resolve the symlink first or operate on the real file directly."
+    );
   }
 
   const isDirectory = stats.isDirectory();
@@ -52,7 +70,7 @@ export async function executeDeleteFile({
     );
   }
 
-  await rm(path, { recursive, force: false });
+  await rm(safePath, { recursive, force: false });
 
   const output: string[] = [];
 
@@ -73,5 +91,5 @@ export async function executeDeleteFile({
 export const deleteFileTool = tool({
   description: DELETE_FILE_DESCRIPTION,
   inputSchema,
-  execute: executeDeleteFile,
+  execute: (input) => executeDeleteFile(input),
 });

--- a/packages/cea/src/tools/modify/edit-file-stress.test.ts
+++ b/packages/cea/src/tools/modify/edit-file-stress.test.ts
@@ -47,7 +47,7 @@ describe("edit_file stress patterns", () => {
     await executeEditFile({
       path: testFile,
       edits: [{ op: "replace", pos: line2, lines: ["literal replaced"] }],
-    });
+    }, { rootDir: tempDir });
     expect(readFileSync(testFile, "utf-8")).toBe(
       "alpha\nliteral replaced\nomega\n"
     );
@@ -64,7 +64,7 @@ describe("edit_file stress patterns", () => {
         { op: "replace", pos: line3, lines: ["L3"] },
         { op: "replace", pos: line4, lines: ["L4"] },
       ],
-    });
+    }, { rootDir: tempDir });
     expect(readFileSync(testFile, "utf-8")).toBe("l1\nL2\nL3\nL4\nl5\n");
   });
 
@@ -77,7 +77,7 @@ describe("edit_file stress patterns", () => {
       edits: [
         { op: "replace", pos: line1, end: line5, lines: ["new-a", "new-b"] },
       ],
-    });
+    }, { rootDir: tempDir });
     expect(readFileSync(testFile, "utf-8")).toBe("new-a\nnew-b\n");
   });
 
@@ -91,7 +91,7 @@ describe("edit_file stress patterns", () => {
         { op: "replace", pos: line1, lines: ["FIRST"] },
         { op: "replace", pos: line4, lines: ["FOURTH"] },
       ],
-    });
+    }, { rootDir: tempDir });
     expect(readFileSync(testFile, "utf-8")).toBe(
       "FIRST\nsecond\nthird\nFOURTH\n"
     );
@@ -107,7 +107,7 @@ describe("edit_file stress patterns", () => {
         { op: "replace", pos: line1, lines: ["TOP"] },
         { op: "append", pos: line3, lines: ["tail"] },
       ],
-    });
+    }, { rootDir: tempDir });
     expect(readFileSync(testFile, "utf-8")).toBe("TOP\nmiddle\nbottom\ntail\n");
   });
 
@@ -124,7 +124,7 @@ describe("edit_file stress patterns", () => {
           lines: ["price = $99.99 (50% off) [limited*]"],
         },
       ],
-    });
+    }, { rootDir: tempDir });
     expect(readFileSync(testFile, "utf-8")).toBe(
       "offer\nprice = $99.99 (50% off) [limited*]\nend\n"
     );
@@ -143,7 +143,7 @@ describe("edit_file stress patterns", () => {
           lines: ["part-1", "part-2", "part-3", "part-4"],
         },
       ],
-    });
+    }, { rootDir: tempDir });
     expect(readFileSync(testFile, "utf-8")).toBe(
       "header\npart-1\npart-2\npart-3\npart-4\nfooter\n"
     );
@@ -160,7 +160,7 @@ describe("edit_file stress patterns", () => {
         { op: "replace", pos: line3, lines: ["THREE"] },
         { op: "append", pos: line5, lines: ["six"] },
       ],
-    });
+    }, { rootDir: tempDir });
     expect(readFileSync(testFile, "utf-8")).toBe(
       "zero\none\ntwo\nTHREE\nfour\nfive\nsix\n"
     );
@@ -173,7 +173,7 @@ describe("edit_file stress patterns", () => {
     await executeEditFile({
       path: testFile,
       edits: [{ op: "replace", pos: line2, lines: ["✅ done — 완료"] }],
-    });
+    }, { rootDir: tempDir });
     expect(readFileSync(testFile, "utf-8")).toBe(
       "alpha\n✅ done — 완료\nomega\n"
     );
@@ -191,7 +191,7 @@ describe("edit_file stress patterns", () => {
       edits: [
         { op: "replace", pos: line4, end: line7, lines: ["new-4", "new-5"] },
       ],
-    });
+    }, { rootDir: tempDir });
     const actualLines = readFileSync(testFile, "utf-8").trimEnd().split("\n");
     expect(actualLines.slice(0, 3)).toEqual(["line-1", "line-2", "line-3"]);
     expect(actualLines.slice(3, 5)).toEqual(["new-4", "new-5"]);

--- a/packages/cea/src/tools/modify/edit-file-whitespace.test.ts
+++ b/packages/cea/src/tools/modify/edit-file-whitespace.test.ts
@@ -50,7 +50,7 @@ describe("edit_file whitespace stress patterns", () => {
     await executeEditFile({
       path: testFile,
       edits: [{ op: "replace", pos: line2, lines: ["updated indented line"] }],
-    });
+    }, { rootDir: tempDir });
     expect(readFileSync(testFile, "utf-8")).toBe(
       "start\n    updated indented line\nend\n"
     );
@@ -63,7 +63,7 @@ describe("edit_file whitespace stress patterns", () => {
     await executeEditFile({
       path: testFile,
       edits: [{ op: "replace", pos: line2, lines: ["filled"] }],
-    });
+    }, { rootDir: tempDir });
     expect(readFileSync(testFile, "utf-8")).toBe("before\n    filled\nafter\n");
   });
 
@@ -74,7 +74,7 @@ describe("edit_file whitespace stress patterns", () => {
     await executeEditFile({
       path: testFile,
       edits: [{ op: "replace", pos: line2, lines: ["return 42;"] }],
-    });
+    }, { rootDir: tempDir });
     expect(readFileSync(testFile, "utf-8")).toBe("start\n\treturn 42;\nend\n");
   });
 
@@ -85,7 +85,7 @@ describe("edit_file whitespace stress patterns", () => {
     await executeEditFile({
       path: testFile,
       edits: [{ op: "append", pos: line1, lines: ["", "new content", ""] }],
-    });
+    }, { rootDir: tempDir });
     expect(readFileSync(testFile, "utf-8")).toBe(
       "anchor\n\nnew content\n\ntail\n"
     );
@@ -98,7 +98,7 @@ describe("edit_file whitespace stress patterns", () => {
     await executeEditFile({
       path: testFile,
       edits: [{ op: "replace", pos: line2, lines: ["hello   "] }],
-    });
+    }, { rootDir: tempDir });
     expect(readFileSync(testFile, "utf-8")).toBe("x\nhello   \n");
   });
 
@@ -109,7 +109,7 @@ describe("edit_file whitespace stress patterns", () => {
     await executeEditFile({
       path: testFile,
       edits: [{ op: "replace", pos: line2, lines: ["updated();"] }],
-    });
+    }, { rootDir: tempDir });
     expect(readFileSync(testFile, "utf-8")).toBe(
       "\tif (ok) {\n    updated();\n\t    mixed();\n}\n"
     );

--- a/packages/cea/src/tools/modify/edit-file.test.ts
+++ b/packages/cea/src/tools/modify/edit-file.test.ts
@@ -11,6 +11,7 @@ import {
   mkdtempSync,
   readFileSync,
   rmSync,
+  symlinkSync,
   writeFileSync,
 } from "node:fs";
 import { tmpdir } from "node:os";
@@ -73,7 +74,7 @@ describe("edit_file (hashline-only)", () => {
           lines: ["BRAVO"],
         },
       ],
-    });
+    }, { rootDir: tempDir });
 
     expect(result).toContain(`Updated ${testFile}`);
     expect(result).toContain("1 edit(s) applied");
@@ -110,7 +111,7 @@ describe("edit_file (hashline-only)", () => {
           lines: ["BRAVO"],
         },
       ],
-    });
+    }, { rootDir: tempDir });
 
     expect(readFileSync(testFile, "utf-8")).toBe("alpha\nBRAVO\ncharlie\n");
   });
@@ -134,7 +135,7 @@ describe("edit_file (hashline-only)", () => {
             lines: ["two-updated"],
           },
         ],
-      })
+      }, { rootDir: tempDir })
     ).rejects.toThrow("changed since last read");
   });
 
@@ -159,7 +160,7 @@ describe("edit_file (hashline-only)", () => {
             lines: ["y-updated"],
           },
         ],
-      })
+      }, { rootDir: tempDir })
     ).rejects.toThrow("File changed since read_file output");
   });
 
@@ -184,7 +185,7 @@ describe("edit_file (hashline-only)", () => {
           lines: ["after-b"],
         },
       ],
-    });
+    }, { rootDir: tempDir });
 
     expect(readFileSync(testFile, "utf-8")).toBe(
       "a\nbefore-b\nb\nafter-b\nc\n"
@@ -202,7 +203,7 @@ describe("edit_file (hashline-only)", () => {
           lines: ["created-via-hashline"],
         },
       ],
-    });
+    }, { rootDir: tempDir });
 
     expect(result).toContain(`Created ${testFile}`);
     expect(result).toContain("1 edit(s) applied");
@@ -217,7 +218,7 @@ describe("edit_file (hashline-only)", () => {
       executeEditFile({
         path: testFile,
         edits: [],
-      })
+      }, { rootDir: tempDir })
     ).rejects.toThrow();
   });
 
@@ -237,7 +238,7 @@ describe("edit_file (hashline-only)", () => {
           lines: ["b"],
         },
       ],
-    });
+    }, { rootDir: tempDir });
     expect(result).toContain("No changes made");
   });
 
@@ -257,7 +258,7 @@ describe("edit_file (hashline-only)", () => {
             pos: lineRef,
           },
         ],
-      })
+      }, { rootDir: tempDir })
     ).rejects.toThrow("explicit 'lines' field");
 
     expect(readFileSync(testFile, "utf-8")).toBe("alpha\nbravo\ncharlie\n");
@@ -277,7 +278,7 @@ describe("edit_file (hashline-only)", () => {
           lines: null,
         },
       ],
-    });
+    }, { rootDir: tempDir });
     expect(readFileSync(testFile, "utf-8")).toBe("body\n");
     // No deletion warning — lines: null is intentional deletion
     expect(result).not.toContain("Deleted");
@@ -297,7 +298,7 @@ describe("edit_file (hashline-only)", () => {
           lines: ["inserted"],
         },
       ],
-    });
+    }, { rootDir: tempDir });
     expect(readFileSync(testFile, "utf-8")).toBe("hello\n\ninserted\nworld\n");
     expect(result).not.toContain("Warnings:");
   });
@@ -319,7 +320,7 @@ describe("edit_file (hashline-only)", () => {
           lines: ["BRAVO"],
         },
       ],
-    });
+    }, { rootDir: tempDir });
 
     expect(readFileSync(testFile, "utf-8")).toBe("alpha\nBRAVO\ncharlie\n");
   });
@@ -341,7 +342,7 @@ describe("edit_file (hashline-only)", () => {
           lines: ["after-bravo"],
         },
       ],
-    });
+    }, { rootDir: tempDir });
 
     expect(readFileSync(testFile, "utf-8")).toBe("alpha\nbravo\nafter-bravo\n");
   });
@@ -363,7 +364,7 @@ describe("edit_file (hashline-only)", () => {
           lines: ["before-bravo"],
         },
       ],
-    });
+    }, { rootDir: tempDir });
 
     expect(readFileSync(testFile, "utf-8")).toBe(
       "alpha\nbefore-bravo\nbravo\n"
@@ -387,7 +388,7 @@ describe("edit_file (hashline-only)", () => {
           lines: ["BRAVO"],
         },
       ],
-    });
+    }, { rootDir: tempDir });
 
     expect(readFileSync(testFile, "utf-8")).toBe("alpha\nBRAVO\n");
   });
@@ -415,7 +416,7 @@ describe("edit_file (hashline-only)", () => {
             pos: multilinePos,
           },
         ],
-      })
+      }, { rootDir: tempDir })
     ).rejects.toThrow("single-line");
 
     expect(readFileSync(testFile, "utf-8")).toBe("alpha\nbravo\ncharlie\n");
@@ -437,7 +438,7 @@ describe("edit_file (hashline-only)", () => {
           lines: ["FOO"],
         },
       ],
-    });
+    }, { rootDir: tempDir });
 
     expect(readFileSync(testFile, "utf-8")).toBe("FOO\r\nbar\r\n");
   });
@@ -458,7 +459,7 @@ describe("edit_file (hashline-only)", () => {
           lines: ["FOO"],
         },
       ],
-    });
+    }, { rootDir: tempDir });
 
     expect(readFileSync(testFile, "utf-8")).toBe("\uFEFFFOO\r\nbar\r\n");
   });
@@ -473,7 +474,7 @@ describe("edit_file (hashline-only)", () => {
       executeEditFile({
         path: testFile,
         edits: [{ op: "replace", pos: `LINE#${hash}`, lines: ["replaced"] }],
-      })
+      }, { rootDir: tempDir })
     ).rejects.toThrow("not a line number");
   });
 
@@ -487,7 +488,7 @@ describe("edit_file (hashline-only)", () => {
       executeEditFile({
         path: testFile,
         edits: [{ op: "replace", pos: `LINE#${hash}`, lines: ["replaced"] }],
-      })
+      }, { rootDir: tempDir })
     ).rejects.toThrow("Did you mean");
   });
 
@@ -503,7 +504,7 @@ describe("edit_file (hashline-only)", () => {
       executeEditFile({
         path: testFile,
         edits: [{ op: "replace", pos: multilinePos, lines: ["x"] }],
-      })
+      }, { rootDir: tempDir })
     ).rejects.toThrow("lines");
   });
 
@@ -515,7 +516,7 @@ describe("edit_file (hashline-only)", () => {
     const result = await executeEditFile({
       path: testFile,
       edits: [{ op: "replace", pos: `>>> ${lineRef}`, lines: ["ALPHA"] }],
-    });
+    }, { rootDir: tempDir });
     expect(result).toContain("1 edit(s) applied");
     expect(readFileSync(testFile, "utf-8")).toBe("ALPHA\nbravo\n");
   });
@@ -527,7 +528,7 @@ describe("edit_file (hashline-only)", () => {
       executeEditFile({
         path: testFile,
         edits: [{ op: "append", pos: "LINE#XX", lines: ["inserted"] }],
-      })
+      }, { rootDir: tempDir })
     ).rejects.toThrow("not a line number");
   });
 
@@ -540,7 +541,7 @@ describe("edit_file (hashline-only)", () => {
       executeEditFile({
         path: testFile,
         edits: [{ op: "replace", pos: "1#ZZ|alpha" }],
-      })
+      }, { rootDir: tempDir })
     ).rejects.toThrow("changed since last read");
   });
 
@@ -554,7 +555,7 @@ describe("edit_file (hashline-only)", () => {
     const result = await executeEditFile({
       path: testFile,
       edits: [{ op: "replace", pos: malformedPos }],
-    });
+    }, { rootDir: tempDir });
 
     expect(
       result.includes("Warnings:") || result.includes("Auto-repaired")
@@ -571,7 +572,7 @@ describe("edit_file (hashline-only)", () => {
       executeEditFile({
         path: testFile,
         edits: [{ op: "replace", pos: "1#ZZ=some content here" }],
-      })
+      }, { rootDir: tempDir })
     ).rejects.toThrow("changed since last read");
   });
 
@@ -587,7 +588,7 @@ describe("edit_file (hashline-only)", () => {
             pos: "1#ZZ']}</parameter><parameter>",
           },
         ],
-      })
+      }, { rootDir: tempDir })
     ).rejects.toThrow("explicit 'lines'");
   });
 
@@ -605,7 +606,7 @@ describe("edit_file (hashline-only)", () => {
           pos: `${line2Anchor}', 'lines': ['REPLACED']}`,
         },
       ],
-    });
+    }, { rootDir: tempDir });
 
     expect(
       result.includes("Warnings:") || result.includes("Auto-repaired")
@@ -622,7 +623,7 @@ describe("edit_file (hashline-only)", () => {
     const result = await executeEditFile({
       path: testFile,
       edits: [{ op: "replace", pos: `${line2Anchor}|old bravo content` }],
-    });
+    }, { rootDir: tempDir });
 
     // Content 'old bravo content' extracted from pos as lines replacement
     expect(result).toContain("Warnings:");
@@ -638,7 +639,7 @@ describe("edit_file (hashline-only)", () => {
       executeEditFile({
         path: testFile,
         edits: [{ op: "replace", pos: "1#ZZ" }],
-      })
+      }, { rootDir: tempDir })
     ).rejects.toThrow("'lines'");
   });
 
@@ -649,7 +650,7 @@ describe("edit_file (hashline-only)", () => {
       executeEditFile({
         path: testFile,
         edits: [{ op: "replace" }],
-      })
+      }, { rootDir: tempDir })
     ).rejects.toThrow("explicit 'lines'");
   });
 
@@ -661,7 +662,7 @@ describe("edit_file (hashline-only)", () => {
       executeEditFile({
         path: testFile,
         edits: [{ op: "replace", pos: longPos }],
-      })
+      }, { rootDir: tempDir })
     ).rejects.toThrow("...");
   });
 });
@@ -894,7 +895,7 @@ describe("repeated failure escalation", () => {
       await executeEditFile({
         path: testFile,
         edits: [{ op: "replace", pos: anchor }],
-      });
+      }, { rootDir: tempDir });
       throw new Error("Expected executeEditFile to reject");
     } catch (error) {
       if (error instanceof Error) {
@@ -1018,7 +1019,7 @@ describe("soft-reject after repeated failures", () => {
         executeEditFile({
           path: testFile,
           edits: [{ op: "replace", pos: line2Anchor }],
-        })
+        }, { rootDir: tempDir })
       ).rejects.toThrow("explicit 'lines'");
     }
 
@@ -1026,7 +1027,7 @@ describe("soft-reject after repeated failures", () => {
     const result = await executeEditFile({
       path: testFile,
       edits: [{ op: "replace", pos: line2Anchor }],
-    });
+    }, { rootDir: tempDir });
 
     expect(typeof result).toBe("string");
     expect(result).toContain("NOT APPLIED");
@@ -1050,7 +1051,7 @@ describe("soft-reject after repeated failures", () => {
         await executeEditFile({
           path: testFile,
           edits: [{ op: "replace", pos: line1Anchor }],
-        });
+        }, { rootDir: tempDir });
       } catch {
         // expected for first 5
       }
@@ -1059,7 +1060,7 @@ describe("soft-reject after repeated failures", () => {
     const result = await executeEditFile({
       path: testFile,
       edits: [{ op: "replace", pos: line1Anchor }],
-    });
+    }, { rootDir: tempDir });
 
     expect(result).toContain("write_file");
   });
@@ -1081,7 +1082,7 @@ describe("soft-reject after repeated failures", () => {
         await executeEditFile({
           path: testFile,
           edits: [{ op: "replace", pos: anchors[i % anchors.length] }],
-        });
+        }, { rootDir: tempDir });
       } catch {
         // expected errors
       }
@@ -1091,7 +1092,7 @@ describe("soft-reject after repeated failures", () => {
     const result = await executeEditFile({
       path: testFile,
       edits: [{ op: "replace", pos: anchors[0] }],
-    });
+    }, { rootDir: tempDir });
 
     expect(typeof result).toBe("string");
     expect(result).toContain("NOT APPLIED");
@@ -1101,5 +1102,130 @@ describe("soft-reject after repeated failures", () => {
     expect(readFileSync(testFile, "utf-8")).toBe(
       "alpha\nbravo\ncharlie\ndelta\n"
     );
+  });
+});
+
+describe("edit_file safety (C-1, C-2, H-1)", () => {
+  let tempDir: string;
+
+  beforeAll(() => {
+    tempDir = mkdtempSync(join(tmpdir(), "edit-file-safety-test-"));
+  });
+
+  afterAll(() => {
+    if (existsSync(tempDir)) {
+      rmSync(tempDir, { recursive: true });
+    }
+  });
+
+  it("C-1: blocks path traversal via .. segments", async () => {
+    const traversalPath = join(tempDir, "..", "..", "etc", "passwd");
+    await expect(
+      executeEditFile(
+        {
+          path: traversalPath,
+          edits: [{ op: "append", lines: ["malicious"] }],
+        },
+        { rootDir: tempDir }
+      )
+    ).rejects.toThrow(/[Pp]ath traversal blocked/);
+  });
+
+  it("C-1: blocks absolute paths outside project root", async () => {
+    await expect(
+      executeEditFile(
+        {
+          path: "/tmp/outside-project-edit.txt",
+          edits: [{ op: "append", lines: ["bad"] }],
+        },
+        { rootDir: tempDir }
+      )
+    ).rejects.toThrow(/[Pp]ath traversal blocked|outside/);
+  });
+
+  it("C-2: blocks edits through symlinks", async () => {
+    const realFile = join(tempDir, "real-edit-target.txt");
+    writeFileSync(realFile, "original\n");
+    const symlinkPath = join(tempDir, "symlink-to-edit.txt");
+    symlinkSync(realFile, symlinkPath);
+
+    await expect(
+      executeEditFile(
+        {
+          path: symlinkPath,
+          edits: [{ op: "append", lines: ["through symlink"] }],
+        },
+        { rootDir: tempDir }
+      )
+    ).rejects.toThrow(/symlink/i);
+
+    // Original file should be unchanged
+    expect(readFileSync(realFile, "utf-8")).toBe("original\n");
+  });
+
+  it("C-2: blocks edits through symlinks pointing outside root", async () => {
+    const outsideDir = mkdtempSync(join(tmpdir(), "outside-edit-root-"));
+    const outsideFile = join(outsideDir, "secret.txt");
+    writeFileSync(outsideFile, "secret data\n");
+    const symlinkPath = join(tempDir, "escape-edit-link.txt");
+    symlinkSync(outsideFile, symlinkPath);
+
+    try {
+      await expect(
+        executeEditFile(
+          {
+            path: symlinkPath,
+            edits: [{ op: "append", lines: ["overwrite"] }],
+          },
+          { rootDir: tempDir }
+        )
+      ).rejects.toThrow(/symlink/i);
+      expect(readFileSync(outsideFile, "utf-8")).toBe("secret data\n");
+    } finally {
+      rmSync(outsideDir, { recursive: true });
+    }
+  });
+
+  it("H-1: edit uses atomic write (no temp file residue)", async () => {
+    const testFile = join(tempDir, "atomic-edit-test.txt");
+    writeFileSync(testFile, "alpha\nbravo\n");
+
+    const readOutput = await executeReadFile({ path: testFile });
+    const lineRef = extractLineRef(readOutput, 1);
+
+    await executeEditFile(
+      {
+        path: testFile,
+        edits: [{ op: "replace", pos: lineRef, lines: ["ALPHA"] }],
+      },
+      { rootDir: tempDir }
+    );
+
+    expect(readFileSync(testFile, "utf-8")).toBe("ALPHA\nbravo\n");
+
+    // Check no .tmp- files remain
+    const { readdirSync } = require("node:fs");
+    const files: string[] = readdirSync(tempDir);
+    const tmpFiles = files.filter((f: string) => f.includes(".tmp-"));
+    expect(tmpFiles.length).toBe(0);
+  });
+
+  it("allows edits within project root (normal operation)", async () => {
+    const safeFile = join(tempDir, "safe-edit.txt");
+    writeFileSync(safeFile, "original content\n");
+
+    const readOutput = await executeReadFile({ path: safeFile });
+    const lineRef = extractLineRef(readOutput, 1);
+
+    const result = await executeEditFile(
+      {
+        path: safeFile,
+        edits: [{ op: "replace", pos: lineRef, lines: ["updated content"] }],
+      },
+      { rootDir: tempDir }
+    );
+
+    expect(result).toContain("Updated");
+    expect(readFileSync(safeFile, "utf-8")).toBe("updated content\n");
   });
 });

--- a/packages/cea/src/tools/modify/write-file.test.ts
+++ b/packages/cea/src/tools/modify/write-file.test.ts
@@ -4,10 +4,11 @@ import {
   mkdtempSync,
   readFileSync,
   rmSync,
+  symlinkSync,
   writeFileSync,
 } from "node:fs";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { join, resolve } from "node:path";
 import { executeWriteFile } from "./write-file";
 
 describe("executeWriteFile", () => {
@@ -28,7 +29,7 @@ describe("executeWriteFile", () => {
       const testFile = join(tempDir, "new.txt");
       const content = "line1\nline2\nline3";
 
-      const result = await executeWriteFile({ path: testFile, content });
+      const result = await executeWriteFile({ path: testFile, content }, { rootDir: tempDir });
 
       expect(result).toContain("OK - created new.txt");
       expect(result).toContain("bytes:");
@@ -45,10 +46,10 @@ describe("executeWriteFile", () => {
       writeFileSync(testFile, "old content");
 
       const newContent = "new content";
-      const result = await executeWriteFile({
-        path: testFile,
-        content: newContent,
-      });
+      const result = await executeWriteFile(
+        { path: testFile, content: newContent },
+        { rootDir: tempDir }
+      );
 
       expect(result).toContain("OK - overwrote existing.txt");
       expect(result).not.toContain("new content");
@@ -61,7 +62,7 @@ describe("executeWriteFile", () => {
       const nestedFile = join(tempDir, "deep", "nested", "dir", "file.txt");
       const content = "nested content";
 
-      const result = await executeWriteFile({ path: nestedFile, content });
+      const result = await executeWriteFile({ path: nestedFile, content }, { rootDir: tempDir });
 
       expect(result).toContain("OK - created file.txt");
       expect(existsSync(nestedFile)).toBe(true);
@@ -76,7 +77,7 @@ describe("executeWriteFile", () => {
       const testFile = join(tempDir, "small.txt");
       const content = "a\nb\nc\nd\ne";
 
-      const result = await executeWriteFile({ path: testFile, content });
+      const result = await executeWriteFile({ path: testFile, content }, { rootDir: tempDir });
 
       expect(result).toContain("bytes:");
       expect(result).toContain("lines: 5");
@@ -89,7 +90,7 @@ describe("executeWriteFile", () => {
       const lines = Array.from({ length: 20 }, (_, i) => `line${i + 1}`);
       const content = lines.join("\n");
 
-      const result = await executeWriteFile({ path: testFile, content });
+      const result = await executeWriteFile({ path: testFile, content }, { rootDir: tempDir });
 
       expect(result).toContain("bytes:");
       expect(result).toContain("lines: 20");
@@ -101,7 +102,7 @@ describe("executeWriteFile", () => {
       const testFile = join(tempDir, "bytes.txt");
       const content = "hello";
 
-      const result = await executeWriteFile({ path: testFile, content });
+      const result = await executeWriteFile({ path: testFile, content }, { rootDir: tempDir });
 
       expect(result).toContain("bytes: 5");
     });
@@ -110,7 +111,7 @@ describe("executeWriteFile", () => {
       const testFile = join(tempDir, "unicode.txt");
       const content = "한글 테스트\n이모지 🎉";
 
-      const result = await executeWriteFile({ path: testFile, content });
+      const result = await executeWriteFile({ path: testFile, content }, { rootDir: tempDir });
 
       expect(result).not.toContain("한글 테스트");
       expect(result).not.toContain("이모지 🎉");
@@ -125,7 +126,7 @@ describe("executeWriteFile", () => {
     it("handles empty content", async () => {
       const testFile = join(tempDir, "empty.txt");
 
-      const result = await executeWriteFile({ path: testFile, content: "" });
+      const result = await executeWriteFile({ path: testFile, content: "" }, { rootDir: tempDir });
 
       expect(result).toContain("OK - created empty.txt");
       expect(result).toContain("bytes: 0");
@@ -139,7 +140,7 @@ describe("executeWriteFile", () => {
       const testFile = join(tempDir, "single.txt");
       const content = "single line without newline";
 
-      const result = await executeWriteFile({ path: testFile, content });
+      const result = await executeWriteFile({ path: testFile, content }, { rootDir: tempDir });
 
       expect(result).toContain("lines: 1");
       expect(result).not.toContain("single line without newline");
@@ -149,10 +150,91 @@ describe("executeWriteFile", () => {
       const testFile = join(tempDir, "special.txt");
       const content = `const x = { a: 1, b: "test" };\nconst y = \`template \${x}\`;`;
 
-      await executeWriteFile({ path: testFile, content });
+      await executeWriteFile({ path: testFile, content }, { rootDir: tempDir });
 
       const written = readFileSync(testFile, "utf-8");
       expect(written).toBe(content);
+    });
+  });
+
+  describe("file safety (C-1, C-2, H-1)", () => {
+    it("C-1: blocks path traversal via .. segments", async () => {
+      const traversalPath = join(tempDir, "..", "..", "etc", "passwd");
+      await expect(
+        executeWriteFile({ path: traversalPath, content: "malicious" }, { rootDir: tempDir })
+      ).rejects.toThrow(/[Pp]ath traversal blocked/);
+    });
+
+    it("C-1: blocks absolute paths outside project root", async () => {
+      await expect(
+        executeWriteFile({ path: "/tmp/outside-project.txt", content: "bad" }, { rootDir: tempDir })
+      ).rejects.toThrow(/[Pp]ath traversal blocked|outside/);
+    });
+
+    it("C-2: blocks writes through symlinks", async () => {
+      const realFile = join(tempDir, "real-target.txt");
+      writeFileSync(realFile, "original");
+      const symlinkPath = join(tempDir, "symlink-to-real.txt");
+      symlinkSync(realFile, symlinkPath);
+
+      await expect(
+        executeWriteFile({ path: symlinkPath, content: "through symlink" }, { rootDir: tempDir })
+      ).rejects.toThrow(/symlink/i);
+
+      // Original file should be unchanged
+      expect(readFileSync(realFile, "utf-8")).toBe("original");
+    });
+
+    it("C-2: blocks writes through symlinks pointing outside root", async () => {
+      const outsideDir = mkdtempSync(join(tmpdir(), "outside-root-"));
+      const outsideFile = join(outsideDir, "secret.txt");
+      writeFileSync(outsideFile, "secret data");
+      const symlinkPath = join(tempDir, "escape-link.txt");
+      symlinkSync(outsideFile, symlinkPath);
+
+      try {
+        await expect(
+          executeWriteFile({ path: symlinkPath, content: "overwrite" }, { rootDir: tempDir })
+        ).rejects.toThrow(/symlink/i);
+        expect(readFileSync(outsideFile, "utf-8")).toBe("secret data");
+      } finally {
+        rmSync(outsideDir, { recursive: true });
+      }
+    });
+
+    it("H-1: atomic write produces correct content (no partial writes)", async () => {
+      const testFile = join(tempDir, "atomic-test.txt");
+      const content = "line1\nline2\nline3";
+
+      await executeWriteFile({ path: testFile, content }, { rootDir: tempDir });
+
+      const written = readFileSync(testFile, "utf-8");
+      expect(written).toBe(content);
+    });
+
+    it("H-1: no temp files left after successful write", async () => {
+      const testFile = join(tempDir, "no-temp-residue.txt");
+      await executeWriteFile({ path: testFile, content: "clean" }, { rootDir: tempDir });
+
+      const dirEntries = readFileSync(testFile, "utf-8");
+      expect(dirEntries).toBe("clean");
+
+      // Check no .tmp- files remain in the directory
+      const { readdirSync } = require("node:fs");
+      const files: string[] = readdirSync(tempDir);
+      const tmpFiles = files.filter((f: string) => f.includes(".tmp-"));
+      expect(tmpFiles.length).toBe(0);
+    });
+
+    it("allows writes within project root (normal operation)", async () => {
+      const safeFile = join(tempDir, "safe-subdir", "nested.txt");
+      const result = await executeWriteFile(
+        { path: safeFile, content: "safe content" },
+        { rootDir: tempDir }
+      );
+
+      expect(result).toContain("OK - created nested.txt");
+      expect(readFileSync(safeFile, "utf-8")).toBe("safe content");
     });
   });
 });

--- a/packages/cea/src/tools/modify/write-file.ts
+++ b/packages/cea/src/tools/modify/write-file.ts
@@ -1,7 +1,8 @@
-import { mkdir, stat, writeFile } from "node:fs/promises";
+import { mkdir } from "node:fs/promises";
 import { basename, dirname } from "node:path";
 import { tool } from "ai";
 import { z } from "zod";
+import { assertWriteSafety, safeAtomicWriteFile } from "../utils/safety-utils";
 import WRITE_FILE_DESCRIPTION from "./write-file.txt";
 
 const inputSchema = z.object({
@@ -11,24 +12,28 @@ const inputSchema = z.object({
 
 export type WriteFileInput = z.infer<typeof inputSchema>;
 
-export async function executeWriteFile({
-  path,
-  content,
-}: WriteFileInput): Promise<string> {
-  const dir = dirname(path);
+export interface WriteFileOptions {
+  /** Override project root for safety checks (defaults to process.cwd()). */
+  rootDir?: string;
+}
+
+export async function executeWriteFile(
+  { path, content }: WriteFileInput,
+  options?: WriteFileOptions
+): Promise<string> {
+  // C-1 + C-2: Path traversal and symlink safety checks
+  const safePath = await assertWriteSafety(path, options?.rootDir);
+
+  const dir = dirname(safePath);
   if (dir !== ".") {
     await mkdir(dir, { recursive: true });
   }
 
-  let existed = false;
-  try {
-    await stat(path);
-    existed = true;
-  } catch {
-    existed = false;
-  }
-
-  await writeFile(path, content, "utf-8");
+  // H-1: Atomic write with O_EXCL temp file + rename.
+  // safeAtomicWriteFile handles existence check (lstat), symlink rejection,
+  // crypto-random temp names, O_EXCL to prevent pre-creation attacks,
+  // and POSIX rename() which does not follow symlinks.
+  const { existed } = await safeAtomicWriteFile(safePath, content);
 
   const lines = content.split("\n");
   const lineCount = lines.length;
@@ -47,5 +52,5 @@ export async function executeWriteFile({
 export const writeFileTool = tool({
   description: WRITE_FILE_DESCRIPTION,
   inputSchema,
-  execute: executeWriteFile,
+  execute: (input) => executeWriteFile(input),
 });


### PR DESCRIPTION
## Summary

Adds path traversal protection, symlink resolution, and atomic write semantics to all file-mutating tools (`write_file`, `edit_file`, `delete_file`).

## Changes

- **`assertWriteSafety` guard** — new validation function that rejects any resolved path outside the project root. Applied to write, edit, and delete operations.
- **Symlink resolution** — uses `lstat` + `realpath` to detect and block writes through symlinks that escape the project root. Handles macOS `/var` → `/private/var` canonical path difference via separate `resolvedRoot` (path traversal check) and `canonicalRoot` (symlink detection).
- **Atomic writes** — `write_file` now writes to a temp file and renames into place, eliminating the window between check and write.
- **Test coverage** — 115 modify-subsystem tests pass, including new traversal/symlink/TOCTOU edge cases.

## Files Changed

| File | Change |
|------|--------|
| `src/tools/utils/safety-utils.ts` | New `assertWriteSafety`, symlink detection, root resolution |
| `src/tools/modify/write-file.ts` | Atomic write (temp + rename), safety guard |
| `src/tools/modify/edit-file.ts` | Safety guard before mutation |
| `src/tools/modify/delete-file.ts` | Safety guard, symlink-aware unlink |
| `src/tools/modify/*.test.ts` | New test cases for traversal, symlinks, TOCTOU |