### PR TITLE
fix(perf): bound message history growth and optimize edit/grep hot paths

### DIFF
--- a/packages/cea/src/entrypoints/cli.ts
+++ b/packages/cea/src/entrypoints/cli.ts
@@ -1220,6 +1220,11 @@ const createCliUi = (skills: SkillInfo[]): CliUi => {
       resolve(null);
     }
 
+    // Release module-level refs to allow GC after UI teardown
+    activeStreamController = null;
+    streamInterruptRequested = false;
+    dismissActiveModal();
+
     removeInputListener();
     process.off("SIGINT", onSigInt);
     process.stdout.off("resize", onTerminalResize);

--- a/packages/cea/src/entrypoints/headless.ts
+++ b/packages/cea/src/entrypoints/headless.ts
@@ -560,6 +560,10 @@ const processAgentResponse = async (
       });
     }
 
+    // Release map contents eagerly so tool-argument strings can be GC'd before next iteration
+    pendingToolCalls.clear();
+    completedToolCallIds.clear();
+
     if (!shouldContinueManualToolLoop(finishReason)) {
       return;
     }

--- a/packages/cea/src/tools/utils/hashline/edit-operations.ts
+++ b/packages/cea/src/tools/utils/hashline/edit-operations.ts
@@ -15,6 +15,15 @@ import {
 import type { HashlineEdit } from "./types";
 import { validateLineRefs } from "./validation";
 
+/** Compare two string arrays element-by-element. O(n) with early exit. */
+function arraysEqual(a: string[], b: string[]): boolean {
+  if (a.length !== b.length) return false;
+  for (let i = 0; i < a.length; i++) {
+    if (a[i] !== b[i]) return false;
+  }
+  return true;
+}
+
 export interface HashlineApplyReport {
   content: string;
   deduplicatedEdits: number;
@@ -69,7 +78,7 @@ export function applyHashlineEditsWithReport(
               skipValidation: true,
             })
           : applySetLine(lines, edit.pos, edit.lines, { skipValidation: true });
-        if (next.join("\n") === lines.join("\n")) {
+        if (arraysEqual(next, lines)) {
           noopEdits += 1;
           break;
         }
@@ -82,7 +91,7 @@ export function applyHashlineEditsWithReport(
               skipValidation: true,
             })
           : applyAppend(lines, edit.lines);
-        if (next.join("\n") === lines.join("\n")) {
+        if (arraysEqual(next, lines)) {
           noopEdits += 1;
           break;
         }
@@ -95,7 +104,7 @@ export function applyHashlineEditsWithReport(
               skipValidation: true,
             })
           : applyPrepend(lines, edit.lines);
-        if (next.join("\n") === lines.join("\n")) {
+        if (arraysEqual(next, lines)) {
           noopEdits += 1;
           break;
         }

--- a/packages/harness/src/index.ts
+++ b/packages/harness/src/index.ts
@@ -1,6 +1,6 @@
 export { createAgent } from "./agent";
 export { runAgentLoop } from "./loop";
-export type { Message } from "./message-history";
+export type { Message, MessageHistoryOptions } from "./message-history";
 export { MessageHistory } from "./message-history";
 export {
   MANUAL_TOOL_LOOP_MAX_STEPS,

--- a/packages/harness/src/message-history.ts
+++ b/packages/harness/src/message-history.ts
@@ -54,6 +54,15 @@ export interface Message {
   originalContent?: string;
 }
 
+export interface MessageHistoryOptions {
+  /**
+   * Maximum number of messages to retain. When exceeded, older messages
+   * are trimmed from the front while preserving the initial user message
+   * for context continuity. Defaults to 1000.
+   */
+  maxMessages?: number;
+}
+
 const createMessageId = (() => {
   let counter = 0;
   return (): string => {
@@ -62,8 +71,21 @@ const createMessageId = (() => {
   };
 })();
 
+const DEFAULT_MAX_MESSAGES = 1000;
+
 export class MessageHistory {
   private messages: Message[] = [];
+  private readonly maxMessages: number;
+
+  constructor(options?: MessageHistoryOptions) {
+    const max = options?.maxMessages ?? DEFAULT_MAX_MESSAGES;
+    if (!Number.isFinite(max) || max < 1 || max !== Math.floor(max)) {
+      throw new RangeError(
+        `maxMessages must be a positive integer >= 1, got ${max}`
+      );
+    }
+    this.maxMessages = max;
+  }
 
   getAll(): Message[] {
     return [...this.messages];
@@ -84,6 +106,7 @@ export class MessageHistory {
       originalContent,
     };
     this.messages.push(message);
+    this.enforceLimit();
     return message;
   }
 
@@ -102,7 +125,58 @@ export class MessageHistory {
       created.push(message);
     }
     this.messages.push(...created);
+    this.enforceLimit();
     return created;
+  }
+
+  private enforceLimit(): void {
+    if (this.messages.length <= this.maxMessages) {
+      return;
+    }
+
+    if (this.maxMessages === 1) {
+      this.messages = [this.messages[this.messages.length - 1]];
+      return;
+    }
+
+    const turnBoundaries: number[] = [];
+    for (let i = 1; i < this.messages.length; i++) {
+      if (this.messages[i].modelMessage.role === "user") {
+        turnBoundaries.push(i);
+      }
+    }
+
+    if (turnBoundaries.length === 0) {
+      this.messages = [
+        this.messages[0],
+        ...this.messages.slice(-(this.maxMessages - 1)),
+      ];
+      return;
+    }
+
+    for (const boundary of turnBoundaries) {
+      const keptCount = 1 + (this.messages.length - boundary);
+      if (keptCount <= this.maxMessages) {
+        this.messages = [this.messages[0], ...this.messages.slice(boundary)];
+        return;
+      }
+    }
+
+    const lastBoundary = turnBoundaries[turnBoundaries.length - 1];
+    const lastBoundaryCandidate = [
+      this.messages[0],
+      ...this.messages.slice(lastBoundary),
+    ];
+
+    if (lastBoundaryCandidate.length <= this.maxMessages) {
+      this.messages = lastBoundaryCandidate;
+      return;
+    }
+
+    this.messages = [
+      this.messages[0],
+      ...this.messages.slice(-(this.maxMessages - 1)),
+    ];
   }
 
   private sanitizeMessage(message: ModelMessage): ModelMessage {
@@ -114,7 +188,7 @@ export class MessageHistory {
       return message;
     }
 
-    const sanitizedContent = message.content.map((part) => {
+    const sanitizedContent = message.content.map((part: any) => {
       if (part.type !== "tool-result") {
         return part;
       }


### PR DESCRIPTION
## Summary

Adds memory bounds to unbounded data structures and replaces `O(n*m)` string comparison with `O(n)` array comparison in the edit engine.

## Changes

- **MessageHistory cap** — new `maxMessages` option (default: 1000). When exceeded, trims older messages while preserving the first message for context continuity. Exposed via `MessageHistoryOptions` type.
- **Circular reference cleanup** — `cli.ts` nullifies `activeStreamController`, `streamInterruptRequested`, and `activeModalCancel` on stream completion. `headless.ts` clears `pendingToolCalls` and `completedToolCallIds` maps after each turn.
- **Edit noop detection** — replaced `next.join("\n") === lines.join("\n")` (creates two full-content strings per comparison) with `arraysEqual()` that does element-wise comparison with early exit.
- **Grep buffer cap** — ripgrep stdout is killed after 10 MB accumulated. stderr capped at 64 KB. Prevents unbounded memory growth on pathological inputs.

## Files Changed

| File | Change |
|------|--------|
| `packages/harness/src/message-history.ts` | `maxMessages` option, `enforceLimit()`, `MessageHistoryOptions` export |
| `packages/harness/src/index.ts` | Export `MessageHistoryOptions` type |
| `packages/cea/src/entrypoints/cli.ts` | Null closure refs on stream end |
| `packages/cea/src/entrypoints/headless.ts` | Clear tool call maps after each turn |
| `packages/cea/src/tools/utils/hashline/edit-operations.ts` | `arraysEqual()` for O(n) noop detection |
| `packages/cea/src/tools/explore/grep.ts` | 10 MB stdout cap, 64 KB stderr cap |

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bound memory growth and optimized hot paths to improve stability and cut CPU/memory. Adds a structure-aware message history cap (default 1000, preserves first turn), caps ripgrep buffers (10 MB stdout, 64 KB stderr), clears stale refs in CLI/headless loops, and replaces join-based no-op checks with an O(n) array compare in edit engine.

<sup>Written for commit 5fc9abf37f2680523a698b9d57e7aeab933921d7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

