### PR TITLE
fix: harden write_file preview rendering and empty-content fallback

### DIFF
--- a/packages/cea/src/interaction/pi-tui-stream-renderer.ts
+++ b/packages/cea/src/interaction/pi-tui-stream-renderer.ts
@@ -1428,8 +1428,17 @@ class ToolCallView extends Container {
       return false;
     }
 
+    const bestInput = this.resolveBestInput();
     const path = this.resolveInputStringField("path") ?? "(unknown)";
+    const fileContent = extractStringField(bestInput, "content");
     const header = buildPrettyHeader("Write", path);
+
+    if (fileContent !== null) {
+      this.setPrettyBlock(header, fileContent, {
+        useBackground: true,
+      });
+      return true;
+    }
 
     if (this.output === undefined) {
       this.setPrettyBlock(header, renderPendingOutput(), {


### PR DESCRIPTION
## Summary
- Bound `write_file` preview rendering to avoid excessive CPU/memory usage on very large generated files.
- Preserve read-style content rendering for normal streamed writes while falling back to write result metadata for empty-content writes.
- Add regression tests for empty-content fallback and bounded large-preview behavior.

## Verification
- `bun run check`
- `bun run test`
- `bun run typecheck`
- `bun run build`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardened write_file rendering to show streamed content as a clean read-style block, limit preview size, and fall back to result metadata for empty writes. This prevents heavy rendering and keeps the output clear.

- **Bug Fixes**
  - Render non-empty write_file content as a read-style block instead of result metadata.
  - Bound preview to 200 lines and 100,000 chars to avoid CPU/memory spikes.
  - Fall back to tool result metadata when content is empty; added regression tests for both behaviors.

<sup>Written for commit 90da57e42137b7fa172ea4713766515e41818292. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

