### PR TITLE
fix(headless): preserve provider default model when --model is omitted

### DIFF
--- a/packages/cea/src/entrypoints/headless-agent-config.test.ts
+++ b/packages/cea/src/entrypoints/headless-agent-config.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from "bun:test";
+import type { ProviderType } from "../agent";
+import type { ReasoningMode } from "../reasoning-mode";
+import type { ToolFallbackMode } from "../tool-fallback-mode";
+import { applyHeadlessAgentConfig } from "./headless-agent-config";
+
+interface CallRecord {
+  args: unknown[];
+  method: string;
+}
+
+const createRecorder = () => {
+  const calls: CallRecord[] = [];
+
+  const record = (method: string, ...args: unknown[]) => {
+    calls.push({ method, args });
+  };
+
+  return {
+    calls,
+    target: {
+      setHeadlessMode: (enabled: boolean) => record("setHeadlessMode", enabled),
+      setModelId: (modelId: string) => record("setModelId", modelId),
+      setProvider: (provider: ProviderType) => record("setProvider", provider),
+      setReasoningMode: (mode: ReasoningMode) =>
+        record("setReasoningMode", mode),
+      setToolFallbackMode: (mode: ToolFallbackMode) =>
+        record("setToolFallbackMode", mode),
+      setTranslationEnabled: (enabled: boolean) =>
+        record("setTranslationEnabled", enabled),
+    },
+  };
+};
+
+describe("applyHeadlessAgentConfig", () => {
+  it("does not overwrite provider default model when --model is omitted", () => {
+    const { calls, target } = createRecorder();
+
+    applyHeadlessAgentConfig(target, {
+      provider: "anthropic",
+      model: undefined,
+      reasoningMode: null,
+      toolFallbackMode: "disable",
+      translateUserPrompts: true,
+    });
+
+    expect(calls.some((call) => call.method === "setModelId")).toBe(false);
+    expect(calls).toContainEqual({
+      method: "setProvider",
+      args: ["anthropic"],
+    });
+  });
+
+  it("applies explicit model when provided", () => {
+    const { calls, target } = createRecorder();
+
+    applyHeadlessAgentConfig(target, {
+      provider: "anthropic",
+      model: "claude-sonnet-4-6",
+      reasoningMode: "on",
+      toolFallbackMode: "morphxml",
+      translateUserPrompts: false,
+    });
+
+    expect(calls).toContainEqual({
+      method: "setModelId",
+      args: ["claude-sonnet-4-6"],
+    });
+    expect(calls).toContainEqual({
+      method: "setReasoningMode",
+      args: ["on"],
+    });
+    expect(calls).toContainEqual({
+      method: "setToolFallbackMode",
+      args: ["morphxml"],
+    });
+    expect(calls).toContainEqual({
+      method: "setTranslationEnabled",
+      args: [false],
+    });
+  });
+});

--- a/packages/cea/src/entrypoints/headless-agent-config.ts
+++ b/packages/cea/src/entrypoints/headless-agent-config.ts
@@ -1,0 +1,42 @@
+import type { ProviderType } from "../agent";
+import type { ReasoningMode } from "../reasoning-mode";
+import type { ToolFallbackMode } from "../tool-fallback-mode";
+
+export interface HeadlessRuntimeOptions {
+  model?: string;
+  provider: ProviderType | null;
+  reasoningMode: ReasoningMode | null;
+  toolFallbackMode: ToolFallbackMode;
+  translateUserPrompts: boolean;
+}
+
+interface HeadlessAgentConfigTarget {
+  setHeadlessMode(enabled: boolean): void;
+  setModelId(modelId: string): void;
+  setProvider(provider: ProviderType): void;
+  setReasoningMode(mode: ReasoningMode): void;
+  setToolFallbackMode(mode: ToolFallbackMode): void;
+  setTranslationEnabled(enabled: boolean): void;
+}
+
+export const applyHeadlessAgentConfig = (
+  target: HeadlessAgentConfigTarget,
+  options: HeadlessRuntimeOptions
+): void => {
+  target.setHeadlessMode(true);
+
+  if (options.provider) {
+    target.setProvider(options.provider);
+  }
+
+  if (options.model) {
+    target.setModelId(options.model);
+  }
+
+  if (options.reasoningMode !== null) {
+    target.setReasoningMode(options.reasoningMode);
+  }
+
+  target.setToolFallbackMode(options.toolFallbackMode);
+  target.setTranslationEnabled(options.translateUserPrompts);
+};

--- a/packages/cea/src/entrypoints/headless.ts
+++ b/packages/cea/src/entrypoints/headless.ts
@@ -5,7 +5,7 @@ import {
   MessageHistory,
   shouldContinueManualToolLoop,
 } from "@ai-sdk-tool/harness";
-import { agentManager, DEFAULT_MODEL_ID, type ProviderType } from "../agent";
+import { agentManager, type ProviderType } from "../agent";
 import { setSessionId } from "../context/session";
 import { translateToEnglish } from "../context/translation";
 import {
@@ -25,6 +25,7 @@ import {
 } from "../tool-fallback-mode";
 import { cleanup } from "../tools/utils/execute/process-manager";
 import { initializeTools } from "../utils/tools-manager";
+import { applyHeadlessAgentConfig } from "./headless-agent-config";
 
 interface BaseEvent {
   sessionId: string;
@@ -591,16 +592,13 @@ const run = async (): Promise<void> => {
 
   setSessionId(sessionId);
 
-  agentManager.setHeadlessMode(true);
-  if (provider) {
-    agentManager.setProvider(provider);
-  }
-  agentManager.setModelId(model || DEFAULT_MODEL_ID);
-  if (reasoningMode !== null) {
-    agentManager.setReasoningMode(reasoningMode);
-  }
-  agentManager.setToolFallbackMode(toolFallbackMode);
-  agentManager.setTranslationEnabled(translateUserPrompts);
+  applyHeadlessAgentConfig(agentManager, {
+    model,
+    provider,
+    reasoningMode,
+    toolFallbackMode,
+    translateUserPrompts,
+  });
 
   const messageHistory = new MessageHistory();
   const preparedPrompt = agentManager.isTranslationEnabled()


### PR DESCRIPTION
## Summary
Headless runtime was always forcing `DEFAULT_MODEL_ID` when `--model` was not provided, even after selecting a provider (e.g. `--provider anthropic`).

This caused provider/model mismatch and ignored provider-specific default model behavior.

## What changed
- Extracted headless agent setup into `applyHeadlessAgentConfig`.
- Changed model assignment logic to:
  - apply provider when provided
  - set model only when `--model` is explicitly provided
- Added regression tests for:
  - not overriding provider default model when `--model` is omitted
  - correctly applying explicit model when `--model` is provided

## Files
- `packages/cea/src/entrypoints/headless.ts`
- `packages/cea/src/entrypoints/headless-agent-config.ts`
- `packages/cea/src/entrypoints/headless-agent-config.test.ts`

## Validation
- `bun run check` ✅
- `bun run test` ✅ (439 pass, 0 fail)

## Impact
- Fixes Anthropic/Friendli provider default model flow in headless mode.
- No breaking API changes.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserve provider default model in headless mode when --model is omitted. This fixes provider/model mismatch and respects provider-specific defaults.

- **Bug Fixes**
  - Stop forcing DEFAULT_MODEL_ID when --model is missing; apply provider and only set model when explicitly provided.
  - Added regression tests for default-model behavior and explicit model selection.

- **Refactors**
  - Centralized headless agent configuration in applyHeadlessAgentConfig.

<sup>Written for commit 32b50129511cef571e3e51037c915ebd1842cdbd. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

