### PR TITLE
fix(cli): prevent CSI-u keyboard sequence leakage on exit by draining…

### DIFF
--- a/packages/cea/src/entrypoints/cli.ts
+++ b/packages/cea/src/entrypoints/cli.ts
@@ -1797,13 +1797,13 @@ const exitWithCleanup = (code: number): never => {
 };
 
 const requestSignalShutdown = (code: number): void => {
-  requestedProcessExitCode = code;
-  shouldExit = true;
-
   if (signalShutdownRequested) {
     return;
   }
   signalShutdownRequested = true;
+
+  requestedProcessExitCode = code;
+  shouldExit = true;
 
   if (activeUiForSignals) {
     activeUiForSignals.requestExit();


### PR DESCRIPTION
… terminal input

- Fixed terminal escape-sequence leakage (`8;1:3u`-style CSI-u fragments) that could appear in shell input after exiting CEA in iTerm/kitty-compatible terminals.
- Updated CLI shutdown flow to always pass through graceful UI disposal, including terminal input draining before TUI stop.
- Unified fast-exit and signal exit paths (`Ctrl+C`, `SIGTERM`, `SIGHUP`, `SIGQUIT`) so they no longer bypass terminal cleanup.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents CSI-u escape sequences from leaking into the shell by draining terminal input and making all exits go through a graceful shutdown. Ctrl+C and signals now request UI exit, drain input, and only then exit with the correct code.

- **Bug Fixes**
  - Drain terminal input before stopping the TUI to prevent CSI-u fragments.
  - Route Ctrl+C and signal exits through UI cleanup; defer process exit until disposal completes.
  - Cancel active stream and clear status on exit requests.

- **Refactors**
  - Make UI dispose async and pass a ProcessTerminal to TUI.
  - Add a unified signal shutdown handler that requests UI exit, preserves exit codes, and ignores duplicates.
  - Track the active UI for signal-driven exits and fall back to immediate exit if the UI isn’t ready.

<sup>Written for commit fb8d81f04962316048561cb8b74e249342a5955d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

