### PR TITLE
fix: harden write_file preview rendering and empty-content fallback

### DIFF
--- a/packages/cea/src/interaction/pi-tui-stream-renderer.ts
+++ b/packages/cea/src/interaction/pi-tui-stream-renderer.ts
@@ -1428,8 +1428,17 @@ class ToolCallView extends Container {
       return false;
     }
 
+    const bestInput = this.resolveBestInput();
     const path = this.resolveInputStringField("path") ?? "(unknown)";
+    const fileContent = extractStringField(bestInput, "content");
     const header = buildPrettyHeader("Write", path);
+
+    if (fileContent !== null) {
+      this.setPrettyBlock(header, fileContent, {
+        useBackground: true,
+      });
+      return true;
+    }
 
     if (this.output === undefined) {
       this.setPrettyBlock(header, renderPendingOutput(), {


### PR DESCRIPTION
## Summary
- Render `write_file` streamed content in a read-style block while keeping the view bounded for very large files.
- Preserve success metadata visibility for empty-content writes instead of showing a blank block.
- Add regression tests for full streamed content, empty-content fallback, and bounded large-preview behavior.

## Verification
- `bun test packages/cea/src/interaction/pi-tui-stream-renderer.test.ts`
- `bun run check`
- `bun run test`
- `bun run typecheck`
- `bun run build`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improve write_file preview to show the actual streamed file content in a readable block. Keep large previews bounded and show result metadata when content is empty.

- **Bug Fixes**
  - Render streamed content in a read-style block from the best input; hide result text when content is present.
  - Limit previews to 200 lines and 100,000 characters and display omitted line count.
  - For empty content, show tool result metadata instead of a blank block. Regression tests cover full stream, empty writes, and truncation behavior.

<sup>Written for commit 90da57e42137b7fa172ea4713766515e41818292. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

