### PR TITLE
fix(cli): persist submitted editor input for up-arrow history

### DIFF
--- a/packages/cea/src/entrypoints/cli.ts
+++ b/packages/cea/src/entrypoints/cli.ts
@@ -1205,6 +1205,10 @@ const createCliUi = (skills: SkillInfo[]): CliUi => {
       return;
     }
 
+    if (text.trim().length > 0) {
+      editor.addToHistory(text);
+    }
+
     pendingExitConfirmation = false;
     lastCtrlCPressAt = 0;
     const resolve = inputResolver;

--- a/packages/cea/src/entrypoints/cli.ts
+++ b/packages/cea/src/entrypoints/cli.ts
@@ -1205,8 +1205,9 @@ const createCliUi = (skills: SkillInfo[]): CliUi => {
       return;
     }
 
-    if (text.trim().length > 0) {
-      editor.addToHistory(text);
+    const trimmed = text.trim();
+    if (trimmed) {
+      editor.addToHistory(trimmed);
     }
 
     pendingExitConfirmation = false;


### PR DESCRIPTION
## Summary
- Add submitted prompt text to `Editor` history in the CLI submit handler.
- Keep history clean by skipping empty/whitespace-only submissions.
- Restore expected Up-arrow recall behavior in interactive mode.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds trimmed submitted editor text to the CLI history so Up-arrow recalls the last prompt in interactive mode. Ignores empty or whitespace-only submissions to keep history clean.

<sup>Written for commit 8bc877709ca758687327b860a4852538eea97ad2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

