### PR TITLE
fix(cli): stabilize Ctrl+C exit flow and add exit notice

### DIFF
--- a/packages/cea/src/entrypoints/cli.ts
+++ b/packages/cea/src/entrypoints/cli.ts
@@ -728,6 +728,10 @@ const createCliUi = (skills: SkillInfo[]): CliUi => {
   };
 
   const isCtrlCInput = (data: string): boolean => {
+    if (isKeyRelease(data) || isKeyRepeat(data)) {
+      return false;
+    }
+
     return data === CTRL_C_ETX || matchesKey(data, Key.ctrl("c"));
   };
 

--- a/packages/cea/src/entrypoints/cli.ts
+++ b/packages/cea/src/entrypoints/cli.ts
@@ -674,6 +674,14 @@ const createCliUi = (skills: SkillInfo[]): CliUi => {
     tui.requestRender();
   };
 
+  const showCtrlCExitNotice = (): void => {
+    clearStatus();
+    statusContainer.addChild(
+      new Text(style(ANSI_CYAN, "Press Ctrl+C again to exit"), 1, 0)
+    );
+    tui.requestRender();
+  };
+
   const showLoader = (message: string): void => {
     clearStatus();
     loader = new Loader(
@@ -695,6 +703,7 @@ const createCliUi = (skills: SkillInfo[]): CliUi => {
 
   const clearPendingExitConfirmation = (): void => {
     pendingExitConfirmation = false;
+    lastCtrlCPressAt = 0;
   };
 
   const setActiveModalCancel = (cancel: (() => void) | null): void => {
@@ -736,6 +745,14 @@ const createCliUi = (skills: SkillInfo[]): CliUi => {
   };
 
   const handleCtrlCPress = (): void => {
+    if (pendingExitConfirmation) {
+      pendingExitConfirmation = false;
+      lastCtrlCPressAt = 0;
+      dismissActiveModal();
+      requestExit();
+      return;
+    }
+
     const now = Date.now();
 
     // Double press within window: request graceful shutdown immediately.
@@ -751,7 +768,7 @@ const createCliUi = (skills: SkillInfo[]): CliUi => {
     const canceled = cancelActiveStream();
     if (canceled) {
       pendingExitConfirmation = true;
-      clearStatus();
+      showCtrlCExitNotice();
       return;
     }
 
@@ -759,6 +776,7 @@ const createCliUi = (skills: SkillInfo[]): CliUi => {
     pendingExitConfirmation = true;
     dismissActiveModal();
     clearPromptInput();
+    showCtrlCExitNotice();
   };
 
   const showReasoningModeSelector = async (


### PR DESCRIPTION
## Summary
- Ignore Ctrl+C key release/repeat events so first Ctrl+C is handled exactly once.
- Show a visible "Press Ctrl+C again to exit" notice after the first Ctrl+C.
- Exit immediately on the second Ctrl+C press instead of requiring an extra press.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stabilizes Ctrl+C behavior in the CLI for predictable exits. First press shows “Press Ctrl+C again to exit”; second press exits immediately, ignoring key release/repeat noise.

- **Bug Fixes**
  - Ignore Ctrl+C key release and repeat events.
  - Show a clear exit notice after the first press.
  - Exit on the second press and reset pending flags/timestamps.

<sup>Written for commit fff777b208a0f64acf3f4be4710fc1d51fff0f79. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

