### PR TITLE
fix(edit-operations): sort before dedupe to ensure order-independent results

### DIFF
--- a/packages/cea/src/tools/utils/hashline/edit-operations.test.ts
+++ b/packages/cea/src/tools/utils/hashline/edit-operations.test.ts
@@ -53,6 +53,7 @@ describe("hashline - edit operations", () => {
       { op: "append", pos: `2#${bHash}`, lines: ["dup"] },
       { op: "append", pos: `2#${bHash}`, lines: ["dup"] },
     ]);
+    // After sorting (line2 at end) and dedupe: only one "dup" remains
     expect(report.content).toBe("a\nb\ndup");
     expect(report.deduplicatedEdits).toBe(1);
   });
@@ -146,6 +147,64 @@ describe("hashline - edit operations", () => {
           op: "replace",
           pos: `2#${bH}`,
           end: `4#${dH}`,
+          lines: ["x", "y", "z"],
+        },
+      ])
+    ).toThrow(OVERLAPPING_REGEX);
+  });
+
+  it("deduplication is order-independent (sorted before dedupe)", () => {
+    // Same edits in different input order should produce same result
+    // Sorting is done by line number (bottom-to-top), then dedupe
+    const content = "a\nb\nc";
+    const bHash = computeLineHash(2, "b");
+    const cHash = computeLineHash(3, "c");
+
+    const editsOrder1 = [
+      { op: "append" as const, pos: `2#${bHash}`, lines: ["dup"] },
+      { op: "append" as const, pos: `3#${cHash}`, lines: ["unique"] },
+      { op: "append" as const, pos: `2#${bHash}`, lines: ["dup"] },
+    ];
+
+    const editsOrder2 = [
+      { op: "append" as const, pos: `2#${bHash}`, lines: ["dup"] },
+      { op: "append" as const, pos: `2#${bHash}`, lines: ["dup"] },
+      { op: "append" as const, pos: `3#${cHash}`, lines: ["unique"] },
+    ];
+
+    const report1 = applyHashlineEditsWithReport(content, editsOrder1);
+    const report2 = applyHashlineEditsWithReport(content, editsOrder2);
+
+    // Both should produce the same result: sorted by line (3, then 2), deduped
+    expect(report1.content).toBe(report2.content);
+    expect(report1.deduplicatedEdits).toBe(report2.deduplicatedEdits);
+    expect(report1.deduplicatedEdits).toBe(1);
+    // After sorting: line3 first, then line2 (bottom-to-top)
+    // Applied: "c" + "unique", then "b" + "dup"
+    expect(report1.content).toBe("a\nb\ndup\nc\nunique");
+  });
+
+  it("overlapping detection works with sorted edits (not original order)", () => {
+    // Overlapping detection should work correctly after sorting
+    const content = "a\nb\nc\nd";
+    const bH = computeLineHash(2, "b");
+    const dH = computeLineHash(4, "d");
+    const aH = computeLineHash(1, "a");
+    const cH = computeLineHash(3, "c");
+
+    // Provide edits in reverse line order - should still detect overlap
+    expect(() =>
+      applyHashlineEdits(content, [
+        {
+          op: "replace",
+          pos: `2#${bH}`,
+          end: `4#${dH}`,
+          lines: ["x", "y", "z"],
+        },
+        {
+          op: "replace",
+          pos: `1#${aH}`,
+          end: `3#${cH}`,
           lines: ["x", "y", "z"],
         },
       ])

--- a/packages/cea/src/tools/utils/hashline/edit-operations.ts
+++ b/packages/cea/src/tools/utils/hashline/edit-operations.ts
@@ -43,13 +43,12 @@ export function applyHashlineEditsWithReport(
     };
   }
 
-  const dedupeResult = dedupeEdits(edits);
   const EDIT_PRECEDENCE: Record<string, number> = {
     replace: 0,
     append: 1,
     prepend: 2,
   };
-  const sortedEdits = [...dedupeResult.edits].sort((a, b) => {
+  const sortedEdits = [...edits].sort((a, b) => {
     const lineA = getEditLineNumber(a);
     const lineB = getEditLineNumber(b);
     if (lineB !== lineA) {
@@ -58,19 +57,22 @@ export function applyHashlineEditsWithReport(
     return (EDIT_PRECEDENCE[a.op] ?? 3) - (EDIT_PRECEDENCE[b.op] ?? 3);
   });
 
+  const dedupeResult = dedupeEdits(sortedEdits);
+  const uniqueEdits = dedupeResult.edits;
+
   let noopEdits = 0;
 
   let lines = content.length === 0 ? [] : content.split("\n");
 
-  const refs = collectLineRefs(sortedEdits);
+  const refs = collectLineRefs(uniqueEdits);
   validateLineRefs(lines, refs);
 
-  const overlapError = detectOverlappingRanges(dedupeResult.edits);
+  const overlapError = detectOverlappingRanges(uniqueEdits);
   if (overlapError) {
     throw new Error(overlapError);
   }
 
-  for (const edit of sortedEdits) {
+  for (const edit of uniqueEdits) {
     switch (edit.op) {
       case "replace": {
         const next = edit.end


### PR DESCRIPTION
Fixes #52

## Problem
The previous implementation ran deduplication before sorting edits. This caused:
1. `detectOverlappingRanges` was called on unsorted edits
2. Deduplication results were dependent on input order (order-dependent)

## Solution
- Sort edits first (bottom-to-top by line number), then deduplicate
- Use deduplicated edits (`uniqueEdits`) for overlap detection and application
- Add tests for order-independent deduplication behavior

## Changes
- `edit-operations.ts`: Reordered sort → dedupe (was: dedupe → sort)
- Added `uniqueEdits` variable to use deduplicated results consistently
- Added 2 new tests:
  - "deduplication is order-independent (sorted before dedupe)"
  - "overlapping detection works with sorted edits (not original order)"

## Verification
```
bun test packages/cea/src/tools/utils/hashline/edit-operations.test.ts
# 14 pass, 0 fail
```

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Sort edits before deduping to make hashline edit operations order-independent and to run overlap detection on the correct set of edits. Fixes #52.

- **Bug Fixes**
  - Sort edits bottom-to-top before dedupe; use deduped edits (uniqueEdits) for ref collection, overlap detection, and application.
  - Add tests for order-independent dedupe and for overlap detection working after sorting.

<sup>Written for commit eddf3c7e608eaac7b84c33ac7ff4b82691891537. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

