### PR TITLE
fix(translation): strengthen CDATA sanitization to prevent XML injection

### DIFF
--- a/packages/cea/src/context/translation.test.ts
+++ b/packages/cea/src/context/translation.test.ts
@@ -152,9 +152,75 @@ describe("translateToEnglish", () => {
 
     expect(result.translated).toBe(true);
     expect(generateTextCallCount).toBe(1);
+    // CDATA end sequence: ]]> becomes ]]&gt; after XML escaping, preventing CDATA closure
     expect(capturedPrompt).toContain(
-      "<user_text><![CDATA[workspace/foo.ts ]]]]><![CDATA[> 구간만 수정해줘]]></user_text>"
+      "<user_text><![CDATA[workspace/foo.ts ]]&gt; 구간만 수정해줘]]></user_text>"
     );
+  });
+
+  it("escapes XML special characters to prevent injection attacks", async () => {
+    translatedOutput = "Safe translation";
+
+    // Include Korean character to ensure translation is triggered
+    const result = await translateToEnglish(
+      '<script>alert("xss")</script> & 테스트',
+      createAgentManagerStub()
+    );
+
+    expect(result.translated).toBe(true);
+    expect(generateTextCallCount).toBe(1);
+    // XML special characters should be escaped
+    expect(capturedPrompt).toContain("&lt;script&gt;");
+    expect(capturedPrompt).toContain("&quot;xss&quot;");
+    expect(capturedPrompt).toContain("&lt;/script&gt;");
+    expect(capturedPrompt).toContain("&amp;");
+  });
+
+  it("handles combined CDATA end sequence and XML special characters", async () => {
+    translatedOutput = "Safe translation";
+
+    // Include Korean character to ensure translation is triggered
+    const result = await translateToEnglish(
+      ']]><script>alert("xss")</script>]]> 테스트',
+      createAgentManagerStub()
+    );
+
+    expect(result.translated).toBe(true);
+    expect(generateTextCallCount).toBe(1);
+    // XML special chars should be escaped
+    expect(capturedPrompt).toContain("&lt;script&gt;");
+    expect(capturedPrompt).toContain("&quot;xss&quot;");
+    // CDATA end sequence: ]]> becomes ]]&gt; after XML escaping
+    expect(capturedPrompt).toContain("]]&gt;");
+  });
+
+  it("escapes single quotes to prevent XML attribute injection", async () => {
+    translatedOutput = "Safe translation";
+
+    // Include Korean character to ensure translation is triggered
+    const result = await translateToEnglish(
+      "It's a test' attr='value 테스트",
+      createAgentManagerStub()
+    );
+
+    expect(result.translated).toBe(true);
+    expect(generateTextCallCount).toBe(1);
+    expect(capturedPrompt).toContain("&apos;");
+  });
+
+  it("handles multiple CDATA end sequences correctly", async () => {
+    translatedOutput = "Safe translation";
+
+    // Include Korean character to ensure translation is triggered
+    const result = await translateToEnglish(
+      "]]>test]]>another]]>end 테스트",
+      createAgentManagerStub()
+    );
+
+    expect(result.translated).toBe(true);
+    expect(generateTextCallCount).toBe(1);
+    // All ]]> sequences should be escaped as ]]&gt;, preventing CDATA closure
+    expect(capturedPrompt).toContain("]]&gt;test]]&gt;another]]&gt;end");
   });
 
   it("skips translation for English input", async () => {

--- a/packages/cea/src/context/translation.ts
+++ b/packages/cea/src/context/translation.ts
@@ -45,11 +45,45 @@ const toErrorMessage = (error: unknown): string => {
   return String(error);
 };
 
-const buildTranslationPrompt = (text: string): string => {
-  const cdataSafeText = text.replaceAll(
+/**
+ * Escapes XML special characters to prevent markup interpretation.
+ * Used as defense-in-depth for user-controlled content in XML contexts.
+ */
+export const escapeXmlEntities = (text: string): string => {
+  return text
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll('"', "&quot;")
+    .replaceAll("'", "&apos;");
+};
+
+/**
+ * Sanitizes text for safe inclusion in XML CDATA section.
+ * Prevents CDATA injection attacks by escaping the CDATA end sequence (]]>)
+ * by splitting into multiple CDATA sections.
+ * 
+ * Note: CDATA sections treat content as literal text, so XML escaping is not
+ * strictly necessary within CDATA. However, we escape the content before
+ * wrapping in CDATA as defense-in-depth against potential XML parser quirks.
+ */
+const sanitizeForCdata = (text: string): string => {
+  // Escape XML entities first (defense in depth)
+  let sanitized = escapeXmlEntities(text);
+
+  // Then handle CDATA end sequence by splitting into multiple CDATA sections
+  // The CDATA_SPLIT_SEQUENCE contains unescaped < and > which are safe here
+  // because they will be inside the CDATA section
+  sanitized = sanitized.replaceAll(
     CDATA_END_SEQUENCE,
     CDATA_SPLIT_SEQUENCE
   );
+
+  return sanitized;
+};
+
+const buildTranslationPrompt = (text: string): string => {
+  const cdataSafeText = sanitizeForCdata(text);
 
   return [
     "<translation_request>",


### PR DESCRIPTION
## Summary

Fixes #50

This PR strengthens the CDATA sanitization in the translation module to prevent potential XML injection attacks.

## Changes

- Enhanced sanitization logic in `buildTranslationPrompt()` to properly handle edge cases
- Prevents indirect prompt injection via translation pipeline
- Addresses CDATA splitting vulnerabilities that could create valid XML fragments

## Security Impact

- Mitigates potential XML injection through translation text processing
- Ensures user content is safely wrapped without interpretation as XML markup

## Related

- Issue #50: Bug: `translation.ts` CDATA injection — insufficient sanitization of user text allows XML escape

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Strengthened CDATA and XML sanitization in the translation prompt to block XML injection and indirect prompt injection. Fixes #50.

- **Bug Fixes**
  - Escape XML entities (&, <, >, ", ') via new escapeXmlEntities().
  - Sanitize text before CDATA; neutralize ]]> by converting to ]]&gt;.
  - Apply sanitization in buildTranslationPrompt().
  - Add tests for special chars, CDATA sequences, and attribute injection cases.

<sup>Written for commit 57950ddbf1a25681c477ce2c7337df791076b107. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

