### PR TITLE
docs(readme): fix bunx CLI command

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ No framework overhead. No abstraction tax. Just the interface between model and 
 
 ```bash
 export FRIENDLI_TOKEN=your_token_here
-bunx github:minpeter/plugsuits#main
+bunx plugsuits
 ```
 
 ### Local development


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Updated the README to use the correct bunx command: bunx plugsuits, replacing the outdated GitHub source reference.
This lets users run the CLI directly and avoids setup/run errors.

<sup>Written for commit a80fc2a771735ae5bd1adc6f208c1d47aeec80a4. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

