### PR TITLE
fix(env): sync .env.example, add provider validation and base URL support (#36, #37, #42)

### DIFF
--- a/.changeset/env-provider-dx.md
+++ b/.changeset/env-provider-dx.md
@@ -1,0 +1,5 @@
+---
+"@ai-sdk-tool/cea": patch
+---
+
+Fix .env.example to match actual env vars, add startup provider validation, and support custom base URLs for provider endpoints

--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,12 @@
+# Provider credentials (at least one required)
 FRIENDLI_TOKEN=your_friendli_token_here
-DEBUG_CHUNK_LOG=false
+ANTHROPIC_API_KEY=your_anthropic_api_key_here
+
+# Custom base URLs for self-hosted deployments and proxies (optional)
+FRIENDLI_BASE_URL=https://inference.friendli.ai/v1
+ANTHROPIC_BASE_URL=https://api.anthropic.com
+
+# Debug options (optional, default: false)
+DEBUG_SHOW_FINISH_REASON=false
+DEBUG_SHOW_TOOL_RESULTS=false
+DEBUG_SHOW_RAW_TOOL_IO=false

--- a/packages/cea/src/agent.ts
+++ b/packages/cea/src/agent.ts
@@ -56,12 +56,14 @@ const friendli = env.FRIENDLI_TOKEN
   ? createFriendli({
       apiKey: env.FRIENDLI_TOKEN,
       includeUsage: true,
+      ...(env.FRIENDLI_BASE_URL ? { baseURL: env.FRIENDLI_BASE_URL } : {}),
     })
   : null;
 
 const anthropic = env.ANTHROPIC_API_KEY
   ? createAnthropic({
       apiKey: env.ANTHROPIC_API_KEY,
+      ...(env.ANTHROPIC_BASE_URL ? { baseURL: env.ANTHROPIC_BASE_URL } : {}),
     })
   : null;
 

--- a/packages/cea/src/entrypoints/cli.ts
+++ b/packages/cea/src/entrypoints/cli.ts
@@ -62,7 +62,7 @@ import { toPromptsCommandName } from "../context/skill-command-prefix";
 import type { SkillInfo } from "../context/skills";
 import { loadAllSkills } from "../context/skills";
 import { isNonEnglish, translateToEnglish } from "../context/translation";
-import { env } from "../env";
+import { env, validateProviderConfig } from "../env";
 import { renderFullStreamWithPiTui } from "../interaction/pi-tui-stream-renderer";
 import { setSpinnerOutputEnabled } from "../interaction/spinner";
 import {
@@ -1780,6 +1780,7 @@ const processInput = async (ui: CliUi, input: string): Promise<boolean> => {
 };
 
 const run = async (): Promise<void> => {
+  validateProviderConfig();
   await initializeTools();
   cachedSkills = await loadAllSkills();
   setSpinnerOutputEnabled(false);

--- a/packages/cea/src/entrypoints/headless.ts
+++ b/packages/cea/src/entrypoints/headless.ts
@@ -27,6 +27,7 @@ import {
 } from "../tool-fallback-mode";
 import { cleanup } from "../tools/utils/execute/process-manager";
 import { initializeTools } from "../utils/tools-manager";
+import { validateProviderConfig } from "../env";
 import { applyHeadlessAgentConfig } from "./headless-agent-config";
 
 interface BaseEvent {
@@ -501,6 +502,7 @@ const processAgentResponse = async (
 };
 
 const run = async (): Promise<void> => {
+  validateProviderConfig();
   await initializeTools();
 
   const {

--- a/packages/cea/src/env.ts
+++ b/packages/cea/src/env.ts
@@ -4,7 +4,9 @@ import { z } from "zod";
 export const env = createEnv({
   server: {
     FRIENDLI_TOKEN: z.string().min(1).optional(),
+    FRIENDLI_BASE_URL: z.string().url().optional(),
     ANTHROPIC_API_KEY: z.string().min(1).optional(),
+    ANTHROPIC_BASE_URL: z.string().url().optional(),
     DEBUG_SHOW_FINISH_REASON: z.stringbool().default(false),
     DEBUG_SHOW_TOOL_RESULTS: z.stringbool().default(false),
     DEBUG_SHOW_RAW_TOOL_IO: z.stringbool().default(false),
@@ -12,3 +14,16 @@ export const env = createEnv({
   runtimeEnv: process.env,
   emptyStringAsUndefined: true,
 });
+
+export const validateProviderConfig = (): void => {
+  if (!(env.FRIENDLI_TOKEN || env.ANTHROPIC_API_KEY)) {
+    console.error(
+      "Error: No provider credentials found.\n" +
+        "Please set either FRIENDLI_TOKEN or ANTHROPIC_API_KEY in your environment.\n" +
+        "  export FRIENDLI_TOKEN=your_friendli_token_here\n" +
+        "  # or\n" +
+        "  export ANTHROPIC_API_KEY=your_anthropic_api_key_here"
+    );
+    process.exit(1);
+  }
+};


### PR DESCRIPTION
## Summary

- **Closes #36**: Sync `.env.example` with actual env vars — removes stale `DEBUG_CHUNK_LOG`, adds `ANTHROPIC_API_KEY`, all debug vars, and base URL vars
- **Closes #37**: Add startup provider validation — if neither `FRIENDLI_TOKEN` nor `ANTHROPIC_API_KEY` is set, print a clear error and `exit(1)` before showing TUI or running headless
- **Closes #42**: Add `FRIENDLI_BASE_URL` and `ANTHROPIC_BASE_URL` env vars to support custom endpoints for self-hosted deployments and proxies

## Changes

### `packages/cea/src/env.ts`
- Added `FRIENDLI_BASE_URL: z.string().url().optional()`
- Added `ANTHROPIC_BASE_URL: z.string().url().optional()`
- Exported `validateProviderConfig()` — exits with clear error if no provider credentials found

### `.env.example`
- Removed stale `DEBUG_CHUNK_LOG` (never existed in `env.ts`)
- Added `ANTHROPIC_API_KEY`
- Added `FRIENDLI_BASE_URL` and `ANTHROPIC_BASE_URL` with defaults
- Added all debug vars: `DEBUG_SHOW_FINISH_REASON`, `DEBUG_SHOW_TOOL_RESULTS`, `DEBUG_SHOW_RAW_TOOL_IO`

### `packages/cea/src/agent.ts`
- Pass `baseURL: env.FRIENDLI_BASE_URL` to `createFriendli()` when set
- Pass `baseURL: env.ANTHROPIC_BASE_URL` to `createAnthropic()` when set

### `packages/cea/src/entrypoints/cli.ts` + `headless.ts`
- Call `validateProviderConfig()` at the start of `run()` — before TUI or headless execution begins

## Verification

- `bun run typecheck`: ✅ PASS
- `bun test ./packages/cea/src`: ✅ 475 pass, 0 fail (no regressions)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Syncs `.env.example` with real env vars, adds startup provider validation, and supports custom base URLs for Friendli and Anthropic to improve DX and self-hosted/proxy setups. Addresses #36, #37, #42.

- **New Features**
  - `FRIENDLI_BASE_URL` and `ANTHROPIC_BASE_URL` env vars; passed to client creation when set.
  - `validateProviderConfig()` runs at CLI/headless startup; exits with a clear error if neither `FRIENDLI_TOKEN` nor `ANTHROPIC_API_KEY` is set.

- **Bug Fixes**
  - `.env.example` now matches actual env: removes `DEBUG_CHUNK_LOG`, adds `ANTHROPIC_API_KEY`, base URL vars, and all debug flags.

<sup>Written for commit b540a605982fe5edfe60a6eac634d1f141cc2e00. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

