### PR TITLE
fix(security): add path containment and result limit to glob tool

### DIFF
--- a/.changeset/security-hardening.md
+++ b/.changeset/security-hardening.md
@@ -1,0 +1,12 @@
+---
+"@ai-sdk-tool/cea": patch
+---
+
+fix(security): add path containment and result limit to glob tool
+
+Prevents symlink traversal outside the search directory by resolving
+each matched file with `realpath()` and verifying containment. Files
+that resolve outside `searchDir` (via symlinks) are silently excluded.
+Broken symlinks are also silently skipped. Adds a 10,000-candidate
+scan limit before the stat phase to bound computational work, reported
+as `glob_limit_reached` in the output.

--- a/packages/cea/src/tools/explore/glob.test.ts
+++ b/packages/cea/src/tools/explore/glob.test.ts
@@ -4,6 +4,7 @@ import {
   mkdirSync,
   mkdtempSync,
   rmSync,
+  symlinkSync,
   writeFileSync,
 } from "node:fs";
 import { tmpdir } from "node:os";
@@ -212,6 +213,85 @@ describe("executeGlob", () => {
           rmSync(repoDir, { recursive: true });
         }
       }
+    });
+  });
+  describe("security: symlink containment", () => {
+    it("excludes files accessed via directory symlink pointing outside searchDir", async () => {
+      const outerDir = mkdtempSync(join(tmpdir(), "glob-outer-"));
+      const innerDir = mkdtempSync(join(tmpdir(), "glob-inner-"));
+      try {
+        writeFileSync(join(outerDir, "secret.txt"), "secret");
+        // Create a directory symlink inside innerDir pointing to outerDir
+        symlinkSync(outerDir, join(innerDir, "link_to_outer"));
+
+        const result = await executeGlob({
+          pattern: "**/*.txt",
+          path: innerDir,
+        });
+
+        // secret.txt is accessible via symlink but outside searchDir — excluded
+        expect(result).toContain("file_count: 0");
+        expect(result).not.toContain("secret.txt");
+      } finally {
+        rmSync(outerDir, { recursive: true, force: true });
+        rmSync(innerDir, { recursive: true, force: true });
+      }
+    });
+
+    it("excludes file symlinks pointing outside searchDir", async () => {
+      const outerDir = mkdtempSync(join(tmpdir(), "glob-outer2-"));
+      const innerDir = mkdtempSync(join(tmpdir(), "glob-inner2-"));
+      try {
+        writeFileSync(join(outerDir, "secret.ts"), "secret");
+        writeFileSync(join(innerDir, "real.ts"), "real");
+        // Create a file symlink pointing outside innerDir
+        symlinkSync(join(outerDir, "secret.ts"), join(innerDir, "link_secret.ts"));
+
+        const result = await executeGlob({
+          pattern: "**/*.ts",
+          path: innerDir,
+        });
+
+        expect(result).toContain("file_count: 1");
+        expect(result).toContain("real.ts");
+        expect(result).not.toContain("secret.ts");
+      } finally {
+        rmSync(outerDir, { recursive: true, force: true });
+        rmSync(innerDir, { recursive: true, force: true });
+      }
+    });
+
+    it("handles broken symlinks gracefully by skipping them", async () => {
+      const testDir = mkdtempSync(join(tmpdir(), "glob-broken-sym-"));
+      try {
+        writeFileSync(join(testDir, "real.ts"), "content");
+        // Broken symlink: target does not exist
+        symlinkSync("/nonexistent/path/ghost.ts", join(testDir, "broken.ts"));
+
+        const result = await executeGlob({
+          pattern: "**/*.ts",
+          path: testDir,
+        });
+
+        expect(result).toContain("file_count: 1");
+        expect(result).toContain("real.ts");
+      } finally {
+        rmSync(testDir, { recursive: true, force: true });
+      }
+    });
+  });
+
+  describe("security: result limit", () => {
+    it("includes glob_limit_reached field in output", async () => {
+      const result = await executeGlob({ pattern: "**/*", path: tempDir });
+
+      expect(result).toContain("glob_limit_reached:");
+    });
+
+    it("reports glob_limit_reached: false for small result sets", async () => {
+      const result = await executeGlob({ pattern: "**/*", path: tempDir });
+
+      expect(result).toContain("glob_limit_reached: false");
     });
   });
 });

--- a/packages/cea/src/tools/explore/glob.ts
+++ b/packages/cea/src/tools/explore/glob.ts
@@ -1,11 +1,12 @@
-import { stat } from "node:fs/promises";
-import { join, resolve } from "node:path";
+import { realpath, stat } from "node:fs/promises";
+import { join, resolve, sep } from "node:path";
 import { tool } from "ai";
 import { z } from "zod";
 import { formatBlock, getIgnoreFilter } from "../utils/safety-utils";
 import GLOB_FILES_DESCRIPTION from "./glob-files.txt";
 
 const MAX_RESULTS = 500;
+const MAX_GLOB_RESULTS = 10_000; // max candidates scanned before stat phase
 const STAT_CONCURRENCY = 32;
 
 interface FileWithMtime {
@@ -52,10 +53,20 @@ export async function executeGlob({
 }: GlobInput): Promise<string> {
   const searchDir = path ? resolve(path) : process.cwd();
 
+  // Canonicalize searchDir by resolving all symlinks for containment checks.
+  let canonicalSearchDir: string;
+  try {
+    canonicalSearchDir = await realpath(searchDir);
+  } catch {
+    canonicalSearchDir = searchDir;
+  }
+
   const glob = new Bun.Glob(pattern);
   const topFilesByMtime: FileWithMtime[] = [];
   let totalMatches = 0;
   let skippedUnreadable = 0;
+  let candidateCount = 0;
+  let globLimitReached = false;
 
   const ignoreFilter = respect_git_ignore
     ? await getIgnoreFilter(searchDir)
@@ -91,7 +102,33 @@ export async function executeGlob({
       continue;
     }
 
+    // Enforce candidate limit before stat phase.
+    candidateCount += 1;
+    if (candidateCount > MAX_GLOB_RESULTS) {
+      globLimitReached = true;
+      break;
+    }
+
     const absolutePath = join(searchDir, file);
+
+    // Symlink containment: resolve symlinks and verify the real path
+    // stays within searchDir to prevent traversal via symlinks.
+    let realAbsolutePath: string;
+    try {
+      realAbsolutePath = await realpath(absolutePath);
+    } catch {
+      // Broken symlink or inaccessible path — skip silently.
+      continue;
+    }
+
+    if (
+      realAbsolutePath !== canonicalSearchDir &&
+      !realAbsolutePath.startsWith(canonicalSearchDir + sep)
+    ) {
+      // File resolves outside searchDir via symlink — skip silently.
+      continue;
+    }
+
     enqueueStat(absolutePath);
 
     if (pending.size >= STAT_CONCURRENCY) {
@@ -112,6 +149,7 @@ export async function executeGlob({
     `file_count: ${totalMatches}`,
     `truncated: ${truncated}`,
     `skipped_unreadable: ${skippedUnreadable}`,
+    `glob_limit_reached: ${globLimitReached}`,
     "sorted_by: mtime desc",
     "",
   ];


### PR DESCRIPTION
## Summary

- Prevents symlink traversal outside `searchDir` by resolving each matched path with `realpath()` and checking it starts with the canonicalized search directory — files escaping via symlinks are silently excluded
- Handles broken symlinks gracefully by catching `realpath()` errors and skipping those files
- Adds a 10,000-candidate scan limit before the stat phase; when exceeded, scanning stops and `glob_limit_reached: true` is included in the output
- New tests in `glob.test.ts` cover: directory symlinks pointing outside searchDir, file symlinks pointing outside searchDir, broken symlinks, and the `glob_limit_reached` output field

Closes #46

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardened the `glob` tool in `@ai-sdk-tool/cea` by enforcing path containment and adding a 10,000-candidate scan limit. Prevents symlink escape outside `searchDir` and reports `glob_limit_reached` when the cap is hit (addresses #46).

- **Bug Fixes**
  - Resolve each match with `realpath()` and skip files that resolve outside the canonicalized `searchDir`; broken symlinks are skipped silently.
  - Stop scanning after 10,000 candidates and include `glob_limit_reached: <bool>` in the output.

<sup>Written for commit 9b02b57a68d82495cbe18cec6aa60abe37002e44. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

