### PR TITLE
fix(process): prevent PID recycling race in killProcessTree

### DIFF
--- a/.changeset/process-safety.md
+++ b/.changeset/process-safety.md
@@ -1,0 +1,5 @@
+---
+"@ai-sdk-tool/cea": patch
+---
+
+Prevent PID recycling race in killProcessTree by checking activeProcesses before SIGKILL and clearing timeout in finish()

--- a/packages/cea/src/tools/utils/execute/process-manager.test.ts
+++ b/packages/cea/src/tools/utils/execute/process-manager.test.ts
@@ -3,7 +3,15 @@ import { spawn } from "node:child_process";
 import { existsSync, mkdtempSync, realpathSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { executeCommand, killProcessTree } from "./process-manager";
+import {
+  executeCommand,
+  getActiveProcessesForTesting,
+  hasPendingSigkillTimeoutForTesting,
+  killProcessTree,
+  resetProcessManagerForTesting,
+  trackActiveProcessForTesting,
+  untrackActiveProcessForTesting,
+} from "./process-manager";
 import { getShell, getShellArgs } from "./shell-detection";
 
 const FIVE_SECONDS_MS = 5000;
@@ -156,12 +164,15 @@ describe("process-manager", () => {
 
     try {
       await sleep(ABORT_DELAY_MS);
+      // Register pid in activeProcesses so SIGKILL guard allows the kill
+      trackActiveProcessForTesting(pid);
       killProcessTree(pid);
       await sleep(SIGKILL_GRACE_MS);
 
       expect(isProcessAlive(pid)).toBe(false);
     } finally {
-      killProcessTree(pid);
+      killProcessTree(pid, true);
+      resetProcessManagerForTesting();
     }
   }, 10_000);
 
@@ -172,4 +183,73 @@ describe("process-manager", () => {
 
     expect(source.includes("spawnSync")).toBe(false);
   });
+
+  it("activeProcesses is empty after executeCommand completes", async () => {
+    resetProcessManagerForTesting();
+    await executeCommand("echo hello");
+    expect(getActiveProcessesForTesting()).toHaveLength(0);
+  });
+
+  it("killProcessTree skips SIGKILL when pid removed from activeProcesses before timeout", async () => {
+    const shell = getShell();
+    const shellArgs = getShellArgs(shell);
+    const child = spawn(shell, [...shellArgs, "trap '' TERM; exec sleep 30"], {
+      detached: true,
+      stdio: ["ignore", "ignore", "ignore"],
+    });
+
+    const pid = child.pid;
+    expect(pid).toBeDefined();
+    if (!pid) throw new Error("Expected pid to be defined");
+
+    child.unref();
+    await sleep(ABORT_DELAY_MS);
+
+    // killProcessTree adds pid to activeProcesses then schedules SIGKILL
+    killProcessTree(pid);
+    expect(hasPendingSigkillTimeoutForTesting(pid)).toBe(true);
+
+    // Simulate finish() by removing pid from activeProcesses BEFORE the SIGKILL fires.
+    // The guard in the timeout callback: if (!activeProcesses.has(pid)) return;
+    // will detect the removal and skip the SIGKILL.
+    untrackActiveProcessForTesting(pid);
+
+    // Wait past SIGKILL_DELAY_MS (200ms) to confirm SIGKILL was not sent
+    await sleep(400);
+    const aliveAfterDelay = isProcessAlive(pid);
+
+    // Force cleanup now
+    try {
+      process.kill(-pid, "SIGKILL");
+    } catch {
+      // ignore
+    }
+    await sleep(200);
+
+    // Process should still have been alive when we checked (guard blocked SIGKILL)
+    expect(aliveAfterDelay).toBe(true);
+  }, 10_000);
+
+  it("finish() clears pending SIGKILL timeout when process exits from SIGTERM", async () => {
+    resetProcessManagerForTesting();
+
+    const controller = new AbortController();
+    const commandPromise = executeCommand("sleep 30", { signal: controller.signal });
+
+    // Let the process spawn and register in activeProcesses
+    await sleep(10);
+    const pids = getActiveProcessesForTesting();
+    expect(pids.length).toBe(1);
+    const pid = pids[0]!;
+
+    // Abort — triggers killProcessTree which sets a SIGKILL timer
+    controller.abort();
+    expect(hasPendingSigkillTimeoutForTesting(pid)).toBe(true);
+
+    // Wait for process to exit; finish() calls clearScheduledSigkill(pid)
+    const result = await commandPromise;
+    expect(hasPendingSigkillTimeoutForTesting(pid)).toBe(false);
+    expect(getActiveProcessesForTesting()).not.toContain(pid);
+    expect(result.cancelled).toBe(true);
+  }, 10_000);
 });

--- a/packages/cea/src/tools/utils/execute/process-manager.ts
+++ b/packages/cea/src/tools/utils/execute/process-manager.ts
@@ -11,6 +11,7 @@ const TIMEOUT_EXIT_CODE = 124;
 const MAX_IN_MEMORY_OUTPUT_BYTES = 2 * 1024 * 1024;
 const TRIMMED_BUFFER_TARGET_BYTES = 512 * 1024;
 const activeProcesses = new Set<number>();
+const pendingSigkillTimeouts = new Map<number, ReturnType<typeof setTimeout>>();
 
 export interface ExecuteOptions {
   onChunk?: (chunk: string) => void;
@@ -60,6 +61,16 @@ function safeKillProcessGroup(pid: number, signal: NodeJS.Signals): void {
     }
     throw error;
   }
+}
+
+function clearScheduledSigkill(pid: number): void {
+  const handle = pendingSigkillTimeouts.get(pid);
+  if (!handle) {
+    return;
+  }
+
+  clearTimeout(handle);
+  pendingSigkillTimeouts.delete(pid);
 }
 
 function resolveExitCode(
@@ -112,16 +123,38 @@ export function killProcessTree(pid: number, force = false): void {
   safeKillProcessGroup(pid, "SIGTERM");
 
   if (force) {
-    safeKillProcessGroup(pid, "SIGKILL");
+    clearScheduledSigkill(pid);
+    try {
+      safeKillProcessGroup(pid, "SIGKILL");
+    } finally {
+      activeProcesses.delete(pid);
+    }
+    return;
+  }
+
+  activeProcesses.add(pid);
+
+  if (pendingSigkillTimeouts.has(pid)) {
     return;
   }
 
   const handle = setTimeout(() => {
-    if (!isProcessGroupAlive(pid)) {
+    pendingSigkillTimeouts.delete(pid);
+    if (!activeProcesses.has(pid)) {
       return;
     }
-    safeKillProcessGroup(pid, "SIGKILL");
+    if (!isProcessGroupAlive(pid)) {
+      activeProcesses.delete(pid);
+      return;
+    }
+
+    try {
+      safeKillProcessGroup(pid, "SIGKILL");
+    } finally {
+      activeProcesses.delete(pid);
+    }
   }, SIGKILL_DELAY_MS);
+  pendingSigkillTimeouts.set(pid, handle);
   if (typeof handle === "object" && "unref" in handle) {
     handle.unref();
   }
@@ -180,6 +213,9 @@ export async function executeCommand(
     let settled = false;
 
     const timeoutHandle = setTimeout(() => {
+      if (settled) {
+        return;
+      }
       timedOut = true;
       if (child.pid) {
         killProcessTree(child.pid);
@@ -239,6 +275,7 @@ export async function executeCommand(
       settled = true;
 
       if (child.pid) {
+        clearScheduledSigkill(child.pid);
         activeProcesses.delete(child.pid);
       }
 
@@ -299,12 +336,35 @@ export async function executeCommand(
 }
 
 export function cleanup(force = false): void {
-  for (const pid of activeProcesses) {
+  for (const pid of [...activeProcesses]) {
     try {
       killProcessTree(pid, force);
     } catch {
       // Best-effort cleanup: continue killing remaining processes
     }
   }
+}
+
+export function getActiveProcessesForTesting(): number[] {
+  return [...activeProcesses];
+}
+
+export function hasPendingSigkillTimeoutForTesting(pid: number): boolean {
+  return pendingSigkillTimeouts.has(pid);
+}
+
+export function trackActiveProcessForTesting(pid: number): void {
+  activeProcesses.add(pid);
+}
+
+export function untrackActiveProcessForTesting(pid: number): void {
+  activeProcesses.delete(pid);
+}
+
+export function resetProcessManagerForTesting(): void {
+  for (const handle of pendingSigkillTimeouts.values()) {
+    clearTimeout(handle);
+  }
+  pendingSigkillTimeouts.clear();
   activeProcesses.clear();
 }


### PR DESCRIPTION
## Summary

Closes #51

- Add `pendingSigkillTimeouts` Map to track SIGKILL timer handles by PID
- Check `activeProcesses.has(pid)` in SIGKILL timeout callback — if PID was removed (e.g. by `finish()` on normal exit), skip the SIGKILL to prevent signaling recycled PIDs
- Call `clearScheduledSigkill(pid)` in the `close` event handler before `activeProcesses.delete(pid)` to cancel the pending SIGKILL
- Ensure `activeProcesses.delete(pid)` is called on all exit paths including forced SIGKILL
- Export testing helpers for fine-grained unit testing of the activeProcesses state

## Verification

- `bun test packages/cea/src/tools/utils/execute/process-manager.test.ts`: ✅ 12 pass, 0 fail
- `bun run typecheck`: ✅ PASS

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents sending SIGKILL to recycled PIDs by hardening `killProcessTree` with pending timer tracking and PID guards. Safer shutdowns and more reliable process cleanup.

- **Bug Fixes**
  - Added `pendingSigkillTimeouts` to track SIGKILL timers and clear them on normal exit and forced kills.
  - Guarded SIGKILL timeout callback to skip if PID is no longer in `activeProcesses` or the group is already dead.
  - Always remove PIDs from `activeProcesses` on every exit path and improved `cleanup()` to avoid mutation during iteration.
  - Exported small test helpers (`getActiveProcessesForTesting`, `hasPendingSigkillTimeoutForTesting`, etc.) for precise unit tests.

<sup>Written for commit f658135dddd654cb58aedb829062c71885852704. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

