### PR TITLE
fix(execute): handle compound commands in noninteractive wrapper

### DIFF
--- a/.changeset/command-wrapping.md
+++ b/.changeset/command-wrapping.md
@@ -1,0 +1,5 @@
+---
+"@ai-sdk-tool/cea": patch
+---
+
+Handle compound commands in noninteractive wrapper — skip suffix arg injection for piped and chained commands to prevent incorrect command corruption

--- a/packages/cea/src/tools/utils/execute/noninteractive-wrapper.test.ts
+++ b/packages/cea/src/tools/utils/execute/noninteractive-wrapper.test.ts
@@ -304,3 +304,54 @@ describe("getFullWrappedCommand", () => {
     expect(result.length).toBeLessThan(1000);
   });
 });
+
+describe("compound command handling", () => {
+  it("does not append -y to apt-get update && apt-get install nginx", () => {
+    const result = wrapCommandNonInteractive(
+      "apt-get update && apt-get install nginx"
+    );
+    expect(result.command).toBe("apt-get update && apt-get install nginx");
+    expect(result.command).not.toMatch(/-y/);
+  });
+
+  it("does not append -y to pip install package && pip install other", () => {
+    const result = wrapCommandNonInteractive(
+      "pip install package && pip install other"
+    );
+    expect(result.command).toBe("pip install package && pip install other");
+  });
+
+  it("does not append suffix args to commands with || operator", () => {
+    const result = wrapCommandNonInteractive(
+      "apt-get update || apt-get install nginx"
+    );
+    expect(result.command).toBe("apt-get update || apt-get install nginx");
+    expect(result.command).not.toMatch(/-y/);
+  });
+
+  it("does not append suffix args to commands with ; separator", () => {
+    const result = wrapCommandNonInteractive(
+      "apt-get update ; apt-get install nginx"
+    );
+    expect(result.command).toBe("apt-get update ; apt-get install nginx");
+    expect(result.command).not.toMatch(/-y/);
+  });
+
+  it("does not append suffix args to piped commands", () => {
+    const result = wrapCommandNonInteractive(
+      "apt-get install nginx | tee /tmp/log"
+    );
+    expect(result.command).toBe("apt-get install nginx | tee /tmp/log");
+    expect(result.command).not.toMatch(/-y/);
+  });
+
+  it("still appends -y to simple apt-get install", () => {
+    const result = wrapCommandNonInteractive("apt-get install nginx");
+    expect(result.command).toContain("-y");
+  });
+
+  it("hasFlag does not match -y inside single-quoted argument", () => {
+    const result = wrapCommandNonInteractive("pip install 'package==-y'");
+    expect(result.command).not.toMatch(/ -y$/);
+  });
+});

--- a/packages/cea/src/tools/utils/execute/noninteractive-wrapper.ts
+++ b/packages/cea/src/tools/utils/execute/noninteractive-wrapper.ts
@@ -199,8 +199,35 @@ const TOOL_PATTERNS: ToolPattern[] = [
 
 const WHITESPACE_SPLIT_PATTERN = /\s+/;
 
+function isCompoundCommand(command: string): boolean {
+  let inSingle = false;
+  let inDouble = false;
+  for (let i = 0; i < command.length; i++) {
+    const ch = command[i];
+    if (ch === "'" && !inDouble) { inSingle = !inSingle; continue; }
+    if (ch === '"' && !inSingle) { inDouble = !inDouble; continue; }
+    if (inSingle || inDouble) continue;
+    const twoChar = command.slice(i, i + 2);
+    if (twoChar === '&&' || twoChar === '||') return true;
+    if (ch === ';' || ch === '|') return true;
+  }
+  return false;
+}
+
 function hasFlag(command: string, flag: string): boolean {
-  return command.split(WHITESPACE_SPLIT_PATTERN).includes(flag);
+  const tokens: string[] = [];
+  let current = '';
+  let inSingle = false;
+  let inDouble = false;
+  for (const ch of command) {
+    if (ch === "'" && !inDouble) { inSingle = !inSingle; current += ch; }
+    else if (ch === '"' && !inSingle) { inDouble = !inDouble; current += ch; }
+    else if ((ch === ' ' || ch === '\t') && !inSingle && !inDouble) {
+      if (current) { tokens.push(current); current = ''; }
+    } else { current += ch; }
+  }
+  if (current) tokens.push(current);
+  return tokens.includes(flag);
 }
 
 function insertArgsAfterCommand(
@@ -221,11 +248,12 @@ function insertArgsAfterCommand(
 }
 
 function appendArgs(command: string, args: string[]): string {
+  if (isCompoundCommand(command)) return command;
   const argsToAdd = args.filter((arg) => !hasFlag(command, arg));
   if (argsToAdd.length === 0) {
     return command;
   }
-  return `${command} ${argsToAdd.join(" ")}`;
+  return `${command} ${argsToAdd.join(' ')}`;
 }
 
 function getBaseEnv(): Record<string, string> {


### PR DESCRIPTION
## Summary

Closes #48

- Add `isCompoundCommand()` to detect unquoted `&&`, `||`, `;`, `|` operators (quote-aware)
- Fix `appendArgs()` to skip suffix arg injection for compound/piped commands
- Fix `hasFlag()` to tokenize respecting single and double quotes (e.g. `pip install 'package==-y'` no longer matches `-y`)
- Existing simple commands continue to get `-y`, `--non-interactive`, `-auto-approve` as before
- 7 new test cases covering all compound operator types and quoted argument edge case

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Skip non-interactive suffix injection for piped/chained shell commands to prevent command corruption, and make flag parsing quote-aware; simple commands still get `-y`, `--non-interactive`, or `-auto-approve`. Closes #48.

- **Bug Fixes**
  - Detect unquoted compound/pipe operators (`&&`, `||`, `;`, `|`) and skip suffix arg injection to keep commands intact.
  - Parse flags with quote awareness so tokens inside single/double quotes don't match flags (e.g., don’t match `-y` in `pip install 'package==-y'`).
  - Add 7 tests covering compound operators, pipelines, and quoted-arg edge cases.

<sup>Written for commit af700c8860df12ff513c1b2e8e9125872a2b0e51. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

