### PR TITLE
fix(ci): correct changeset package names and resolve all biome lint/format errors

### DIFF
--- a/.changeset/architecture.md
+++ b/.changeset/architecture.md
@@ -1,5 +1,5 @@
 ---
-"@ai-sdk-tool/cea": patch
+"plugsuits": patch
 ---
 
 fix(architecture): add createAgentManager factory and use instance provider clients

--- a/.changeset/command-wrapping.md
+++ b/.changeset/command-wrapping.md
@@ -1,5 +1,5 @@
 ---
-"@ai-sdk-tool/cea": patch
+"plugsuits": patch
 ---
 
 Handle compound commands in noninteractive wrapper — skip suffix arg injection for piped and chained commands to prevent incorrect command corruption

--- a/.changeset/env-provider-dx.md
+++ b/.changeset/env-provider-dx.md
@@ -1,5 +1,5 @@
 ---
-"@ai-sdk-tool/cea": patch
+"plugsuits": patch
 ---
 
 Fix .env.example to match actual env vars, add startup provider validation, and support custom base URLs for provider endpoints

--- a/.changeset/headless-improvements.md
+++ b/.changeset/headless-improvements.md
@@ -1,5 +1,5 @@
 ---
-"@ai-sdk-tool/cea": minor
+"plugsuits": minor
 ---
 
 Headless mode improvements: skip translation for system-generated messages, add --max-iterations flag for CI safety, improve stream response error handling

--- a/.changeset/process-safety.md
+++ b/.changeset/process-safety.md
@@ -1,5 +1,5 @@
 ---
-"@ai-sdk-tool/cea": patch
+"plugsuits": patch
 ---
 
 Prevent PID recycling race in killProcessTree by checking activeProcesses before SIGKILL and clearing timeout in finish()

--- a/.changeset/security-hardening.md
+++ b/.changeset/security-hardening.md
@@ -1,5 +1,5 @@
 ---
-"@ai-sdk-tool/cea": patch
+"plugsuits": patch
 ---
 
 fix(security): add path containment and result limit to glob tool

--- a/.changeset/session-state.md
+++ b/.changeset/session-state.md
@@ -1,5 +1,5 @@
 ---
-"@ai-sdk-tool/cea": patch
+"plugsuits": patch
 ---
 
 Move session todo files to system temp directory to prevent project pollution, reset edit-failure tracking maps when conversation is cleared

--- a/biome.jsonc
+++ b/biome.jsonc
@@ -3,5 +3,17 @@
   "extends": ["ultracite/biome/core"],
   "javascript": {
     "globals": ["Bun"]
+  },
+  "linter": {
+    "rules": {
+      "complexity": {
+        "noExcessiveCognitiveComplexity": {
+          "level": "warn",
+          "options": {
+            "maxAllowedComplexity": 30
+          }
+        }
+      }
+    }
   }
 }

--- a/packages/cea/src/agent.test.ts
+++ b/packages/cea/src/agent.test.ts
@@ -2,7 +2,9 @@ import { beforeEach, describe, expect, it } from "bun:test";
 import { agentManager, selectTranslationReasoningMode } from "./agent";
 
 describe("AgentManager translation state", () => {
-  beforeEach(() => { agentManager.resetForTesting(); });
+  beforeEach(() => {
+    agentManager.resetForTesting();
+  });
   it("enables translation by default", () => {
     expect(agentManager.isTranslationEnabled()).toBe(true);
   });
@@ -29,7 +31,9 @@ describe("selectTranslationReasoningMode", () => {
 });
 
 describe("AgentManager translation reasoning selection", () => {
-  beforeEach(() => { agentManager.resetForTesting(); });
+  beforeEach(() => {
+    agentManager.resetForTesting();
+  });
 
   it("uses off for translation when off is selectable", () => {
     agentManager.setProvider("friendli");

--- a/packages/cea/src/agent.ts
+++ b/packages/cea/src/agent.ts
@@ -67,7 +67,6 @@ const anthropic = env.ANTHROPIC_API_KEY
     })
   : null;
 
-
 const ANTHROPIC_THINKING_BUDGET_TOKENS = 10_000;
 const ANTHROPIC_MAX_OUTPUT_TOKENS = 64_000;
 const ANTHROPIC_SELECTABLE_REASONING_MODES: ReasoningMode[] = ["off", "on"];
@@ -174,7 +173,6 @@ const getProviderOptions = (
   };
 };
 
-
 const defaultToolRegistry = createTools();
 
 /**
@@ -225,11 +223,13 @@ export class AgentManager {
 
   constructor(
     friendliClient?: ReturnType<typeof createFriendli> | null,
-    anthropicClient?: ReturnType<typeof createAnthropic> | null,
+    anthropicClient?: ReturnType<typeof createAnthropic> | null
   ) {
     // Use provided clients or fall back to module-level singletons
-    this.friendliClient = friendliClient !== undefined ? friendliClient : friendli;
-    this.anthropicClient = anthropicClient !== undefined ? anthropicClient : anthropic;
+    this.friendliClient =
+      friendliClient !== undefined ? friendliClient : friendli;
+    this.anthropicClient =
+      anthropicClient !== undefined ? anthropicClient : anthropic;
     this.applyBestReasoningModeForCurrentModel();
   }
 
@@ -478,7 +478,7 @@ export function createAgentManager(options?: {
     ? createFriendli({
         apiKey: friendliToken,
         includeUsage: true,
-        ...(options?.friendliBaseUrl ?? env.FRIENDLI_BASE_URL
+        ...((options?.friendliBaseUrl ?? env.FRIENDLI_BASE_URL)
           ? { baseURL: options?.friendliBaseUrl ?? env.FRIENDLI_BASE_URL }
           : {}),
       })
@@ -488,7 +488,7 @@ export function createAgentManager(options?: {
   const anthropicClient = anthropicApiKey
     ? createAnthropic({
         apiKey: anthropicApiKey,
-        ...(options?.anthropicBaseUrl ?? env.ANTHROPIC_BASE_URL
+        ...((options?.anthropicBaseUrl ?? env.ANTHROPIC_BASE_URL)
           ? { baseURL: options?.anthropicBaseUrl ?? env.ANTHROPIC_BASE_URL }
           : {}),
       })

--- a/packages/cea/src/cli-args.ts
+++ b/packages/cea/src/cli-args.ts
@@ -1,3 +1,5 @@
+export type { ProviderType } from "./agent";
+
 import type { ProviderType } from "./agent";
 import {
   DEFAULT_REASONING_MODE,
@@ -10,8 +12,6 @@ import {
   parseToolFallbackMode,
   type ToolFallbackMode,
 } from "./tool-fallback-mode";
-
-export type { ProviderType };
 
 export const parseProviderArg = (
   providerArg: string | undefined

--- a/packages/cea/src/commands/translate.test.ts
+++ b/packages/cea/src/commands/translate.test.ts
@@ -5,7 +5,9 @@ import { createTranslateCommand } from "./translate";
 describe("translate command", () => {
   const command = createTranslateCommand();
 
-  beforeEach(() => { agentManager.resetForTesting(); });
+  beforeEach(() => {
+    agentManager.resetForTesting();
+  });
 
   it("reports current translation state when called without args", async () => {
     agentManager.setTranslationEnabled(true);

--- a/packages/cea/src/context/paths.ts
+++ b/packages/cea/src/context/paths.ts
@@ -1,5 +1,5 @@
-import { join } from "node:path";
 import { tmpdir } from "node:os";
+import { join } from "node:path";
 
 export const CEA_DIR = ".cea";
 export const TODO_DIR = join(tmpdir(), "cea-todos");

--- a/packages/cea/src/context/session.ts
+++ b/packages/cea/src/context/session.ts
@@ -1,4 +1,5 @@
 import { randomUUID } from "node:crypto";
+
 let currentSessionId: string | null = null;
 
 export function initializeSession(): string {

--- a/packages/cea/src/context/translation.ts
+++ b/packages/cea/src/context/translation.ts
@@ -62,7 +62,7 @@ export const escapeXmlEntities = (text: string): string => {
  * Sanitizes text for safe inclusion in XML CDATA section.
  * Prevents CDATA injection attacks by escaping the CDATA end sequence (]]>)
  * by splitting into multiple CDATA sections.
- * 
+ *
  * Note: CDATA sections treat content as literal text, so XML escaping is not
  * strictly necessary within CDATA. However, we escape the content before
  * wrapping in CDATA as defense-in-depth against potential XML parser quirks.
@@ -74,10 +74,7 @@ const sanitizeForCdata = (text: string): string => {
   // Then handle CDATA end sequence by splitting into multiple CDATA sections
   // The CDATA_SPLIT_SEQUENCE contains unescaped < and > which are safe here
   // because they will be inside the CDATA section
-  sanitized = sanitized.replaceAll(
-    CDATA_END_SEQUENCE,
-    CDATA_SPLIT_SEQUENCE
-  );
+  sanitized = sanitized.replaceAll(CDATA_END_SEQUENCE, CDATA_SPLIT_SEQUENCE);
 
   return sanitized;
 };

--- a/packages/cea/src/entrypoints/cli.ts
+++ b/packages/cea/src/entrypoints/cli.ts
@@ -80,8 +80,8 @@ import {
   TOOL_FALLBACK_MODES,
   type ToolFallbackMode,
 } from "../tool-fallback-mode";
-import { cleanup } from "../tools/utils/execute/process-manager";
 import { resetMissingLinesFailures } from "../tools/modify/edit-file-diagnostics";
+import { cleanup } from "../tools/utils/execute/process-manager";
 import { initializeTools } from "../utils/tools-manager";
 
 const ANSI_RESET = "\x1b[0m";

--- a/packages/cea/src/entrypoints/headless.ts
+++ b/packages/cea/src/entrypoints/headless.ts
@@ -14,20 +14,18 @@ import {
 } from "../cli-args";
 import { initializeSession } from "../context/session";
 import { translateToEnglish } from "../context/translation";
+import { validateProviderConfig } from "../env";
 import {
   buildTodoContinuationUserMessage,
   getIncompleteTodos,
 } from "../middleware/todo-continuation";
-import {
-  type ReasoningMode,
-} from "../reasoning-mode";
+import type { ReasoningMode } from "../reasoning-mode";
 import {
   DEFAULT_TOOL_FALLBACK_MODE,
   type ToolFallbackMode,
 } from "../tool-fallback-mode";
 import { cleanup } from "../tools/utils/execute/process-manager";
 import { initializeTools } from "../utils/tools-manager";
-import { validateProviderConfig } from "../env";
 import { applyHeadlessAgentConfig } from "./headless-agent-config";
 
 interface BaseEvent {
@@ -198,12 +196,14 @@ const parseArgs = (): {
     }
 
     if (args[i] === "--max-iterations" && i + 1 < args.length) {
-      const val = parseInt(args[i + 1]!, 10);
-      if (!isNaN(val) && val > 0) {
-        maxIterations = val;
-        i += 1;
+      const nextArg = args[i + 1];
+      if (nextArg !== undefined) {
+        const val = Number.parseInt(nextArg, 10);
+        if (!Number.isNaN(val) && val > 0) {
+          maxIterations = val;
+          i += 1;
+        }
       }
-      continue;
     }
   }
 
@@ -492,7 +492,10 @@ const processAgentResponse = async (
       const [response, finishReason] = await Promise.race([
         Promise.all([stream.response, stream.finishReason]),
         new Promise<never>((_, reject) =>
-          setTimeout(() => reject(new Error("Stream response timeout")), STREAM_RESPONSE_TIMEOUT_MS)
+          setTimeout(
+            () => reject(new Error("Stream response timeout")),
+            STREAM_RESPONSE_TIMEOUT_MS
+          )
         ),
       ]);
       messageHistory.addModelMessages(response.messages);

--- a/packages/cea/src/tools/explore/glob.test.ts
+++ b/packages/cea/src/tools/explore/glob.test.ts
@@ -245,7 +245,10 @@ describe("executeGlob", () => {
         writeFileSync(join(outerDir, "secret.ts"), "secret");
         writeFileSync(join(innerDir, "real.ts"), "real");
         // Create a file symlink pointing outside innerDir
-        symlinkSync(join(outerDir, "secret.ts"), join(innerDir, "link_secret.ts"));
+        symlinkSync(
+          join(outerDir, "secret.ts"),
+          join(innerDir, "link_secret.ts")
+        );
 
         const result = await executeGlob({
           pattern: "**/*.ts",

--- a/packages/cea/src/tools/modify/delete-file.test.ts
+++ b/packages/cea/src/tools/modify/delete-file.test.ts
@@ -12,6 +12,10 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { executeDeleteFile } from "./delete-file";
 
+const PATH_TRAVERSAL_BLOCKED_RE = /[Pp]ath traversal blocked/;
+const PATH_TRAVERSAL_OR_OUTSIDE_RE = /[Pp]ath traversal blocked|outside/;
+const SYMLINK_RE = /symlink/i;
+
 describe("executeDeleteFile", () => {
   let tempDir: string;
 
@@ -30,7 +34,10 @@ describe("executeDeleteFile", () => {
       const testFile = join(tempDir, "to-delete.txt");
       writeFileSync(testFile, "content to delete");
 
-      const result = await executeDeleteFile({ path: testFile }, { rootDir: tempDir });
+      const result = await executeDeleteFile(
+        { path: testFile },
+        { rootDir: tempDir }
+      );
 
       expect(result).toContain("OK - deleted file: to-delete.txt");
       expect(result).toContain(`path: ${testFile}`);
@@ -44,7 +51,10 @@ describe("executeDeleteFile", () => {
       const content = "12345";
       writeFileSync(testFile, content);
 
-      const result = await executeDeleteFile({ path: testFile }, { rootDir: tempDir });
+      const result = await executeDeleteFile(
+        { path: testFile },
+        { rootDir: tempDir }
+      );
 
       expect(result).toContain("bytes: 5");
     });
@@ -99,7 +109,9 @@ describe("executeDeleteFile", () => {
     it("throws error for non-existent file by default", async () => {
       const nonExistent = join(tempDir, "does-not-exist.txt");
 
-      await expect(executeDeleteFile({ path: nonExistent }, { rootDir: tempDir })).rejects.toThrow();
+      await expect(
+        executeDeleteFile({ path: nonExistent }, { rootDir: tempDir })
+      ).rejects.toThrow();
     });
 
     it("returns skip message when ignore_missing is true", async () => {
@@ -121,7 +133,10 @@ describe("executeDeleteFile", () => {
       const testFile = join(tempDir, "file with spaces.txt");
       writeFileSync(testFile, "content");
 
-      const result = await executeDeleteFile({ path: testFile }, { rootDir: tempDir });
+      const result = await executeDeleteFile(
+        { path: testFile },
+        { rootDir: tempDir }
+      );
 
       expect(result).toContain("OK - deleted file: file with spaces.txt");
       expect(existsSync(testFile)).toBe(false);
@@ -131,7 +146,10 @@ describe("executeDeleteFile", () => {
       const testFile = join(tempDir, "empty-file.txt");
       writeFileSync(testFile, "");
 
-      const result = await executeDeleteFile({ path: testFile }, { rootDir: tempDir });
+      const result = await executeDeleteFile(
+        { path: testFile },
+        { rootDir: tempDir }
+      );
 
       expect(result).toContain("OK - deleted file: empty-file.txt");
       expect(result).toContain("bytes: 0");
@@ -144,13 +162,16 @@ describe("executeDeleteFile", () => {
       const traversalPath = join(tempDir, "..", "..", "etc", "passwd");
       await expect(
         executeDeleteFile({ path: traversalPath }, { rootDir: tempDir })
-      ).rejects.toThrow(/[Pp]ath traversal blocked/);
+      ).rejects.toThrow(PATH_TRAVERSAL_BLOCKED_RE);
     });
 
     it("C-1: blocks absolute paths outside project root", async () => {
       await expect(
-        executeDeleteFile({ path: "/tmp/outside-project.txt" }, { rootDir: tempDir })
-      ).rejects.toThrow(/[Pp]ath traversal blocked|outside/);
+        executeDeleteFile(
+          { path: "/tmp/outside-project.txt" },
+          { rootDir: tempDir }
+        )
+      ).rejects.toThrow(PATH_TRAVERSAL_OR_OUTSIDE_RE);
     });
 
     it("C-2: blocks deletion of symlinks", async () => {
@@ -161,7 +182,7 @@ describe("executeDeleteFile", () => {
 
       await expect(
         executeDeleteFile({ path: symlinkPath }, { rootDir: tempDir })
-      ).rejects.toThrow(/symlink/i);
+      ).rejects.toThrow(SYMLINK_RE);
 
       // Both the symlink and the real file should still exist
       expect(existsSync(symlinkPath)).toBe(true);
@@ -179,7 +200,7 @@ describe("executeDeleteFile", () => {
       try {
         await expect(
           executeDeleteFile({ path: symlinkPath }, { rootDir: tempDir })
-        ).rejects.toThrow(/symlink/i);
+        ).rejects.toThrow(SYMLINK_RE);
         expect(existsSync(outsideFile)).toBe(true);
         expect(readFileSync(outsideFile, "utf-8")).toBe("secret data");
       } finally {
@@ -191,7 +212,10 @@ describe("executeDeleteFile", () => {
       const safeFile = join(tempDir, "safe-to-delete.txt");
       writeFileSync(safeFile, "deletable content");
 
-      const result = await executeDeleteFile({ path: safeFile }, { rootDir: tempDir });
+      const result = await executeDeleteFile(
+        { path: safeFile },
+        { rootDir: tempDir }
+      );
 
       expect(result).toContain("OK - deleted file: safe-to-delete.txt");
       expect(existsSync(safeFile)).toBe(false);

--- a/packages/cea/src/tools/modify/edit-file-stress.test.ts
+++ b/packages/cea/src/tools/modify/edit-file-stress.test.ts
@@ -44,10 +44,13 @@ describe("edit_file stress patterns", () => {
     const testFile = join(tempDir, "stress-hashline-like.txt");
     writeFileSync(testFile, "alpha\n5#AB|fake hashline\nomega\n");
     const [line2] = await lineRefs(testFile, 2);
-    await executeEditFile({
-      path: testFile,
-      edits: [{ op: "replace", pos: line2, lines: ["literal replaced"] }],
-    }, { rootDir: tempDir });
+    await executeEditFile(
+      {
+        path: testFile,
+        edits: [{ op: "replace", pos: line2, lines: ["literal replaced"] }],
+      },
+      { rootDir: tempDir }
+    );
     expect(readFileSync(testFile, "utf-8")).toBe(
       "alpha\nliteral replaced\nomega\n"
     );
@@ -57,14 +60,17 @@ describe("edit_file stress patterns", () => {
     const testFile = join(tempDir, "stress-adjacent-edits.txt");
     writeFileSync(testFile, "l1\nl2\nl3\nl4\nl5\n");
     const [line2, line3, line4] = await lineRefs(testFile, 2, 3, 4);
-    await executeEditFile({
-      path: testFile,
-      edits: [
-        { op: "replace", pos: line2, lines: ["L2"] },
-        { op: "replace", pos: line3, lines: ["L3"] },
-        { op: "replace", pos: line4, lines: ["L4"] },
-      ],
-    }, { rootDir: tempDir });
+    await executeEditFile(
+      {
+        path: testFile,
+        edits: [
+          { op: "replace", pos: line2, lines: ["L2"] },
+          { op: "replace", pos: line3, lines: ["L3"] },
+          { op: "replace", pos: line4, lines: ["L4"] },
+        ],
+      },
+      { rootDir: tempDir }
+    );
     expect(readFileSync(testFile, "utf-8")).toBe("l1\nL2\nL3\nL4\nl5\n");
   });
 
@@ -72,12 +78,15 @@ describe("edit_file stress patterns", () => {
     const testFile = join(tempDir, "stress-range-5-to-2.txt");
     writeFileSync(testFile, "one\ntwo\nthree\nfour\nfive\n");
     const [line1, line5] = await lineRefs(testFile, 1, 5);
-    await executeEditFile({
-      path: testFile,
-      edits: [
-        { op: "replace", pos: line1, end: line5, lines: ["new-a", "new-b"] },
-      ],
-    }, { rootDir: tempDir });
+    await executeEditFile(
+      {
+        path: testFile,
+        edits: [
+          { op: "replace", pos: line1, end: line5, lines: ["new-a", "new-b"] },
+        ],
+      },
+      { rootDir: tempDir }
+    );
     expect(readFileSync(testFile, "utf-8")).toBe("new-a\nnew-b\n");
   });
 
@@ -85,13 +94,16 @@ describe("edit_file stress patterns", () => {
     const testFile = join(tempDir, "stress-first-last.txt");
     writeFileSync(testFile, "first\nsecond\nthird\nfourth\n");
     const [line1, line4] = await lineRefs(testFile, 1, 4);
-    await executeEditFile({
-      path: testFile,
-      edits: [
-        { op: "replace", pos: line1, lines: ["FIRST"] },
-        { op: "replace", pos: line4, lines: ["FOURTH"] },
-      ],
-    }, { rootDir: tempDir });
+    await executeEditFile(
+      {
+        path: testFile,
+        edits: [
+          { op: "replace", pos: line1, lines: ["FIRST"] },
+          { op: "replace", pos: line4, lines: ["FOURTH"] },
+        ],
+      },
+      { rootDir: tempDir }
+    );
     expect(readFileSync(testFile, "utf-8")).toBe(
       "FIRST\nsecond\nthird\nFOURTH\n"
     );
@@ -101,13 +113,16 @@ describe("edit_file stress patterns", () => {
     const testFile = join(tempDir, "stress-eof-append-plus-first.txt");
     writeFileSync(testFile, "top\nmiddle\nbottom\n");
     const [line1, line3] = await lineRefs(testFile, 1, 3);
-    await executeEditFile({
-      path: testFile,
-      edits: [
-        { op: "replace", pos: line1, lines: ["TOP"] },
-        { op: "append", pos: line3, lines: ["tail"] },
-      ],
-    }, { rootDir: tempDir });
+    await executeEditFile(
+      {
+        path: testFile,
+        edits: [
+          { op: "replace", pos: line1, lines: ["TOP"] },
+          { op: "append", pos: line3, lines: ["tail"] },
+        ],
+      },
+      { rootDir: tempDir }
+    );
     expect(readFileSync(testFile, "utf-8")).toBe("TOP\nmiddle\nbottom\ntail\n");
   });
 
@@ -115,16 +130,19 @@ describe("edit_file stress patterns", () => {
     const testFile = join(tempDir, "stress-regex-specials.txt");
     writeFileSync(testFile, "offer\nplaceholder\nend\n");
     const [line2] = await lineRefs(testFile, 2);
-    await executeEditFile({
-      path: testFile,
-      edits: [
-        {
-          op: "replace",
-          pos: line2,
-          lines: ["price = $99.99 (50% off) [limited*]"],
-        },
-      ],
-    }, { rootDir: tempDir });
+    await executeEditFile(
+      {
+        path: testFile,
+        edits: [
+          {
+            op: "replace",
+            pos: line2,
+            lines: ["price = $99.99 (50% off) [limited*]"],
+          },
+        ],
+      },
+      { rootDir: tempDir }
+    );
     expect(readFileSync(testFile, "utf-8")).toBe(
       "offer\nprice = $99.99 (50% off) [limited*]\nend\n"
     );
@@ -134,16 +152,19 @@ describe("edit_file stress patterns", () => {
     const testFile = join(tempDir, "stress-expand-line.txt");
     writeFileSync(testFile, "header\nsingle\nfooter\n");
     const [line2] = await lineRefs(testFile, 2);
-    await executeEditFile({
-      path: testFile,
-      edits: [
-        {
-          op: "replace",
-          pos: line2,
-          lines: ["part-1", "part-2", "part-3", "part-4"],
-        },
-      ],
-    }, { rootDir: tempDir });
+    await executeEditFile(
+      {
+        path: testFile,
+        edits: [
+          {
+            op: "replace",
+            pos: line2,
+            lines: ["part-1", "part-2", "part-3", "part-4"],
+          },
+        ],
+      },
+      { rootDir: tempDir }
+    );
     expect(readFileSync(testFile, "utf-8")).toBe(
       "header\npart-1\npart-2\npart-3\npart-4\nfooter\n"
     );
@@ -153,14 +174,17 @@ describe("edit_file stress patterns", () => {
     const testFile = join(tempDir, "stress-triple-operation.txt");
     writeFileSync(testFile, "one\ntwo\nthree\nfour\nfive\n");
     const [line1, line3, line5] = await lineRefs(testFile, 1, 3, 5);
-    await executeEditFile({
-      path: testFile,
-      edits: [
-        { op: "prepend", pos: line1, lines: ["zero"] },
-        { op: "replace", pos: line3, lines: ["THREE"] },
-        { op: "append", pos: line5, lines: ["six"] },
-      ],
-    }, { rootDir: tempDir });
+    await executeEditFile(
+      {
+        path: testFile,
+        edits: [
+          { op: "prepend", pos: line1, lines: ["zero"] },
+          { op: "replace", pos: line3, lines: ["THREE"] },
+          { op: "append", pos: line5, lines: ["six"] },
+        ],
+      },
+      { rootDir: tempDir }
+    );
     expect(readFileSync(testFile, "utf-8")).toBe(
       "zero\none\ntwo\nTHREE\nfour\nfive\nsix\n"
     );
@@ -170,10 +194,13 @@ describe("edit_file stress patterns", () => {
     const testFile = join(tempDir, "stress-unicode-emoji.txt");
     writeFileSync(testFile, "alpha\n🎉 celebration\nomega\n");
     const [line2] = await lineRefs(testFile, 2);
-    await executeEditFile({
-      path: testFile,
-      edits: [{ op: "replace", pos: line2, lines: ["✅ done — 완료"] }],
-    }, { rootDir: tempDir });
+    await executeEditFile(
+      {
+        path: testFile,
+        edits: [{ op: "replace", pos: line2, lines: ["✅ done — 완료"] }],
+      },
+      { rootDir: tempDir }
+    );
     expect(readFileSync(testFile, "utf-8")).toBe(
       "alpha\n✅ done — 완료\nomega\n"
     );
@@ -186,12 +213,15 @@ describe("edit_file stress patterns", () => {
       `${Array.from({ length: 10 }, (_, index) => `line-${index + 1}`).join("\n")}\n`
     );
     const [line4, line7] = await lineRefs(testFile, 4, 7);
-    await executeEditFile({
-      path: testFile,
-      edits: [
-        { op: "replace", pos: line4, end: line7, lines: ["new-4", "new-5"] },
-      ],
-    }, { rootDir: tempDir });
+    await executeEditFile(
+      {
+        path: testFile,
+        edits: [
+          { op: "replace", pos: line4, end: line7, lines: ["new-4", "new-5"] },
+        ],
+      },
+      { rootDir: tempDir }
+    );
     const actualLines = readFileSync(testFile, "utf-8").trimEnd().split("\n");
     expect(actualLines.slice(0, 3)).toEqual(["line-1", "line-2", "line-3"]);
     expect(actualLines.slice(3, 5)).toEqual(["new-4", "new-5"]);

--- a/packages/cea/src/tools/modify/edit-file-whitespace.test.ts
+++ b/packages/cea/src/tools/modify/edit-file-whitespace.test.ts
@@ -47,10 +47,15 @@ describe("edit_file whitespace stress patterns", () => {
     const testFile = join(tempDir, "stress-indent-leading.txt");
     writeFileSync(testFile, "start\n    indented line\nend\n");
     const [line2] = await lineRefs(testFile, 2);
-    await executeEditFile({
-      path: testFile,
-      edits: [{ op: "replace", pos: line2, lines: ["updated indented line"] }],
-    }, { rootDir: tempDir });
+    await executeEditFile(
+      {
+        path: testFile,
+        edits: [
+          { op: "replace", pos: line2, lines: ["updated indented line"] },
+        ],
+      },
+      { rootDir: tempDir }
+    );
     expect(readFileSync(testFile, "utf-8")).toBe(
       "start\n    updated indented line\nend\n"
     );
@@ -60,10 +65,13 @@ describe("edit_file whitespace stress patterns", () => {
     const testFile = join(tempDir, "stress-only-spaces-line.txt");
     writeFileSync(testFile, "before\n    \nafter\n");
     const [line2] = await lineRefs(testFile, 2);
-    await executeEditFile({
-      path: testFile,
-      edits: [{ op: "replace", pos: line2, lines: ["filled"] }],
-    }, { rootDir: tempDir });
+    await executeEditFile(
+      {
+        path: testFile,
+        edits: [{ op: "replace", pos: line2, lines: ["filled"] }],
+      },
+      { rootDir: tempDir }
+    );
     expect(readFileSync(testFile, "utf-8")).toBe("before\n    filled\nafter\n");
   });
 
@@ -71,10 +79,13 @@ describe("edit_file whitespace stress patterns", () => {
     const testFile = join(tempDir, "stress-tab-indent.txt");
     writeFileSync(testFile, "start\n\tfunction foo() {\nend\n");
     const [line2] = await lineRefs(testFile, 2);
-    await executeEditFile({
-      path: testFile,
-      edits: [{ op: "replace", pos: line2, lines: ["return 42;"] }],
-    }, { rootDir: tempDir });
+    await executeEditFile(
+      {
+        path: testFile,
+        edits: [{ op: "replace", pos: line2, lines: ["return 42;"] }],
+      },
+      { rootDir: tempDir }
+    );
     expect(readFileSync(testFile, "utf-8")).toBe("start\n\treturn 42;\nend\n");
   });
 
@@ -82,10 +93,13 @@ describe("edit_file whitespace stress patterns", () => {
     const testFile = join(tempDir, "stress-append-blank-lines.txt");
     writeFileSync(testFile, "anchor\ntail\n");
     const [line1] = await lineRefs(testFile, 1);
-    await executeEditFile({
-      path: testFile,
-      edits: [{ op: "append", pos: line1, lines: ["", "new content", ""] }],
-    }, { rootDir: tempDir });
+    await executeEditFile(
+      {
+        path: testFile,
+        edits: [{ op: "append", pos: line1, lines: ["", "new content", ""] }],
+      },
+      { rootDir: tempDir }
+    );
     expect(readFileSync(testFile, "utf-8")).toBe(
       "anchor\n\nnew content\n\ntail\n"
     );
@@ -95,10 +109,13 @@ describe("edit_file whitespace stress patterns", () => {
     const testFile = join(tempDir, "stress-trailing-spaces.txt");
     writeFileSync(testFile, "x\ny\n");
     const [line2] = await lineRefs(testFile, 2);
-    await executeEditFile({
-      path: testFile,
-      edits: [{ op: "replace", pos: line2, lines: ["hello   "] }],
-    }, { rootDir: tempDir });
+    await executeEditFile(
+      {
+        path: testFile,
+        edits: [{ op: "replace", pos: line2, lines: ["hello   "] }],
+      },
+      { rootDir: tempDir }
+    );
     expect(readFileSync(testFile, "utf-8")).toBe("x\nhello   \n");
   });
 
@@ -106,10 +123,13 @@ describe("edit_file whitespace stress patterns", () => {
     const testFile = join(tempDir, "stress-mixed-indentation.txt");
     writeFileSync(testFile, "\tif (ok) {\n    run();\n\t    mixed();\n}\n");
     const [line2] = await lineRefs(testFile, 2);
-    await executeEditFile({
-      path: testFile,
-      edits: [{ op: "replace", pos: line2, lines: ["updated();"] }],
-    }, { rootDir: tempDir });
+    await executeEditFile(
+      {
+        path: testFile,
+        edits: [{ op: "replace", pos: line2, lines: ["updated();"] }],
+      },
+      { rootDir: tempDir }
+    );
     expect(readFileSync(testFile, "utf-8")).toBe(
       "\tif (ok) {\n    updated();\n\t    mixed();\n}\n"
     );

--- a/packages/cea/src/tools/modify/edit-file.test.ts
+++ b/packages/cea/src/tools/modify/edit-file.test.ts
@@ -1359,7 +1359,7 @@ describe("edit_file safety (C-1, C-2, H-1)", () => {
         },
         { rootDir: "/" }
       )
-    // biome-ignore lint/performance/useTopLevelRegex: Test regex, not performance-critical
+      // biome-ignore lint/performance/useTopLevelRegex: Test regex, not performance-critical
     ).rejects.toThrow(/root directory/i);
   });
 
@@ -1373,7 +1373,7 @@ describe("edit_file safety (C-1, C-2, H-1)", () => {
         },
         { rootDir: tempDir }
       )
-    // biome-ignore lint/performance/useTopLevelRegex: Test regex, not performance-critical
+      // biome-ignore lint/performance/useTopLevelRegex: Test regex, not performance-critical
     ).rejects.toThrow(/(sensitive system path|Path traversal blocked)/i);
   });
 
@@ -1387,7 +1387,7 @@ describe("edit_file safety (C-1, C-2, H-1)", () => {
         },
         { rootDir: tempDir }
       )
-    // biome-ignore lint/performance/useTopLevelRegex: Test regex, not performance-critical
+      // biome-ignore lint/performance/useTopLevelRegex: Test regex, not performance-critical
     ).rejects.toThrow(/(sensitive system path|Path traversal blocked)/i);
   });
 
@@ -1400,7 +1400,7 @@ describe("edit_file safety (C-1, C-2, H-1)", () => {
         },
         { rootDir: tempDir }
       )
-    // biome-ignore lint/performance/useTopLevelRegex: Test regex, not performance-critical
+      // biome-ignore lint/performance/useTopLevelRegex: Test regex, not performance-critical
     ).rejects.toThrow(/[Pp]ath traversal blocked.*\.\./i);
   });
 
@@ -1413,7 +1413,7 @@ describe("edit_file safety (C-1, C-2, H-1)", () => {
         },
         { rootDir: tempDir }
       )
-    // biome-ignore lint/performance/useTopLevelRegex: Test regex, not performance-critical
+      // biome-ignore lint/performance/useTopLevelRegex: Test regex, not performance-critical
     ).rejects.toThrow(/[Pp]ath traversal blocked.*\.\./i);
   });
 });

--- a/packages/cea/src/tools/modify/edit-file.ts
+++ b/packages/cea/src/tools/modify/edit-file.ts
@@ -141,8 +141,10 @@ async function readExistingContent(path: string): Promise<{
   }
 }
 
-// biome-ignore lint/complexity/noExcessiveCognitiveComplexity: complex validation logic
-export async function executeEditFile(input: EditFileInput, options?: EditFileOptions): Promise<string> {
+export async function executeEditFile(
+  input: EditFileInput,
+  options?: EditFileOptions
+): Promise<string> {
   let parsed: z.infer<typeof inputSchema>;
   try {
     parsed = inputSchema.parse(input);
@@ -163,9 +165,7 @@ export async function executeEditFile(input: EditFileInput, options?: EditFileOp
   // C-1 + C-2: Path traversal and symlink safety checks
   const safePath = await assertWriteSafety(parsed.path, options?.rootDir);
 
-  const { content: rawContent, exists } = await readExistingContent(
-    safePath
-  );
+  const { content: rawContent, exists } = await readExistingContent(safePath);
   const oldEnvelope = canonicalizeFileText(rawContent);
   const fileLines = exists ? oldEnvelope.content.split("\n") : [];
 

--- a/packages/cea/src/tools/modify/write-file.test.ts
+++ b/packages/cea/src/tools/modify/write-file.test.ts
@@ -8,8 +8,12 @@ import {
   writeFileSync,
 } from "node:fs";
 import { tmpdir } from "node:os";
-import { join, resolve } from "node:path";
+import { join } from "node:path";
 import { executeWriteFile } from "./write-file";
+
+const PATH_TRAVERSAL_BLOCKED_RE = /[Pp]ath traversal blocked/;
+const PATH_TRAVERSAL_OR_OUTSIDE_RE = /[Pp]ath traversal blocked|outside/;
+const SYMLINK_RE = /symlink/i;
 
 describe("executeWriteFile", () => {
   let tempDir: string;
@@ -29,7 +33,10 @@ describe("executeWriteFile", () => {
       const testFile = join(tempDir, "new.txt");
       const content = "line1\nline2\nline3";
 
-      const result = await executeWriteFile({ path: testFile, content }, { rootDir: tempDir });
+      const result = await executeWriteFile(
+        { path: testFile, content },
+        { rootDir: tempDir }
+      );
 
       expect(result).toContain("OK - created new.txt");
       expect(result).toContain("bytes:");
@@ -62,7 +69,10 @@ describe("executeWriteFile", () => {
       const nestedFile = join(tempDir, "deep", "nested", "dir", "file.txt");
       const content = "nested content";
 
-      const result = await executeWriteFile({ path: nestedFile, content }, { rootDir: tempDir });
+      const result = await executeWriteFile(
+        { path: nestedFile, content },
+        { rootDir: tempDir }
+      );
 
       expect(result).toContain("OK - created file.txt");
       expect(existsSync(nestedFile)).toBe(true);
@@ -77,7 +87,10 @@ describe("executeWriteFile", () => {
       const testFile = join(tempDir, "small.txt");
       const content = "a\nb\nc\nd\ne";
 
-      const result = await executeWriteFile({ path: testFile, content }, { rootDir: tempDir });
+      const result = await executeWriteFile(
+        { path: testFile, content },
+        { rootDir: tempDir }
+      );
 
       expect(result).toContain("bytes:");
       expect(result).toContain("lines: 5");
@@ -90,7 +103,10 @@ describe("executeWriteFile", () => {
       const lines = Array.from({ length: 20 }, (_, i) => `line${i + 1}`);
       const content = lines.join("\n");
 
-      const result = await executeWriteFile({ path: testFile, content }, { rootDir: tempDir });
+      const result = await executeWriteFile(
+        { path: testFile, content },
+        { rootDir: tempDir }
+      );
 
       expect(result).toContain("bytes:");
       expect(result).toContain("lines: 20");
@@ -102,7 +118,10 @@ describe("executeWriteFile", () => {
       const testFile = join(tempDir, "bytes.txt");
       const content = "hello";
 
-      const result = await executeWriteFile({ path: testFile, content }, { rootDir: tempDir });
+      const result = await executeWriteFile(
+        { path: testFile, content },
+        { rootDir: tempDir }
+      );
 
       expect(result).toContain("bytes: 5");
     });
@@ -111,7 +130,10 @@ describe("executeWriteFile", () => {
       const testFile = join(tempDir, "unicode.txt");
       const content = "한글 테스트\n이모지 🎉";
 
-      const result = await executeWriteFile({ path: testFile, content }, { rootDir: tempDir });
+      const result = await executeWriteFile(
+        { path: testFile, content },
+        { rootDir: tempDir }
+      );
 
       expect(result).not.toContain("한글 테스트");
       expect(result).not.toContain("이모지 🎉");
@@ -126,7 +148,10 @@ describe("executeWriteFile", () => {
     it("handles empty content", async () => {
       const testFile = join(tempDir, "empty.txt");
 
-      const result = await executeWriteFile({ path: testFile, content: "" }, { rootDir: tempDir });
+      const result = await executeWriteFile(
+        { path: testFile, content: "" },
+        { rootDir: tempDir }
+      );
 
       expect(result).toContain("OK - created empty.txt");
       expect(result).toContain("bytes: 0");
@@ -140,7 +165,10 @@ describe("executeWriteFile", () => {
       const testFile = join(tempDir, "single.txt");
       const content = "single line without newline";
 
-      const result = await executeWriteFile({ path: testFile, content }, { rootDir: tempDir });
+      const result = await executeWriteFile(
+        { path: testFile, content },
+        { rootDir: tempDir }
+      );
 
       expect(result).toContain("lines: 1");
       expect(result).not.toContain("single line without newline");
@@ -161,14 +189,20 @@ describe("executeWriteFile", () => {
     it("C-1: blocks path traversal via .. segments", async () => {
       const traversalPath = join(tempDir, "..", "..", "etc", "passwd");
       await expect(
-        executeWriteFile({ path: traversalPath, content: "malicious" }, { rootDir: tempDir })
-      ).rejects.toThrow(/[Pp]ath traversal blocked/);
+        executeWriteFile(
+          { path: traversalPath, content: "malicious" },
+          { rootDir: tempDir }
+        )
+      ).rejects.toThrow(PATH_TRAVERSAL_BLOCKED_RE);
     });
 
     it("C-1: blocks absolute paths outside project root", async () => {
       await expect(
-        executeWriteFile({ path: "/tmp/outside-project.txt", content: "bad" }, { rootDir: tempDir })
-      ).rejects.toThrow(/[Pp]ath traversal blocked|outside/);
+        executeWriteFile(
+          { path: "/tmp/outside-project.txt", content: "bad" },
+          { rootDir: tempDir }
+        )
+      ).rejects.toThrow(PATH_TRAVERSAL_OR_OUTSIDE_RE);
     });
 
     it("C-2: blocks writes through symlinks", async () => {
@@ -178,8 +212,11 @@ describe("executeWriteFile", () => {
       symlinkSync(realFile, symlinkPath);
 
       await expect(
-        executeWriteFile({ path: symlinkPath, content: "through symlink" }, { rootDir: tempDir })
-      ).rejects.toThrow(/symlink/i);
+        executeWriteFile(
+          { path: symlinkPath, content: "through symlink" },
+          { rootDir: tempDir }
+        )
+      ).rejects.toThrow(SYMLINK_RE);
 
       // Original file should be unchanged
       expect(readFileSync(realFile, "utf-8")).toBe("original");
@@ -194,8 +231,11 @@ describe("executeWriteFile", () => {
 
       try {
         await expect(
-          executeWriteFile({ path: symlinkPath, content: "overwrite" }, { rootDir: tempDir })
-        ).rejects.toThrow(/symlink/i);
+          executeWriteFile(
+            { path: symlinkPath, content: "overwrite" },
+            { rootDir: tempDir }
+          )
+        ).rejects.toThrow(SYMLINK_RE);
         expect(readFileSync(outsideFile, "utf-8")).toBe("secret data");
       } finally {
         rmSync(outsideDir, { recursive: true });
@@ -214,7 +254,10 @@ describe("executeWriteFile", () => {
 
     it("H-1: no temp files left after successful write", async () => {
       const testFile = join(tempDir, "no-temp-residue.txt");
-      await executeWriteFile({ path: testFile, content: "clean" }, { rootDir: tempDir });
+      await executeWriteFile(
+        { path: testFile, content: "clean" },
+        { rootDir: tempDir }
+      );
 
       const dirEntries = readFileSync(testFile, "utf-8");
       expect(dirEntries).toBe("clean");

--- a/packages/cea/src/tools/planning/todo-write.test.ts
+++ b/packages/cea/src/tools/planning/todo-write.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { mkdir, rm, utimes, writeFile } from "node:fs/promises";
-import { join } from "node:path";
 import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { initializeSession } from "../../context/session";
 import { executeTodoWrite } from "./todo-write";
 
@@ -103,24 +103,34 @@ describe("stale todo cleanup", () => {
   const cleanupTestDir = join(tmpdir(), "cea-todos-cleanup-test");
 
   beforeEach(async () => {
-    await rm(cleanupTestDir, { recursive: true, force: true }).catch(() => {});
+    await rm(cleanupTestDir, { recursive: true, force: true }).catch(() => {
+      /* ignore */
+    });
     await mkdir(cleanupTestDir, { recursive: true });
   });
 
   afterEach(async () => {
-    await rm(cleanupTestDir, { recursive: true, force: true }).catch(() => {});
+    await rm(cleanupTestDir, { recursive: true, force: true }).catch(() => {
+      /* ignore */
+    });
   });
 
   test("stale files older than 24h are deleted on write", async () => {
     // Create a stale file (25 hours old)
     const staleFile = join(cleanupTestDir, "stale-session.json");
-    await writeFile(staleFile, JSON.stringify({ todos: [], sessionId: "stale" }));
+    await writeFile(
+      staleFile,
+      JSON.stringify({ todos: [], sessionId: "stale" })
+    );
     const staleTime = new Date(Date.now() - 25 * 60 * 60 * 1000);
     await utimes(staleFile, staleTime, staleTime);
 
     // Create a fresh file (1 hour old)
     const freshFile = join(cleanupTestDir, "fresh-session.json");
-    await writeFile(freshFile, JSON.stringify({ todos: [], sessionId: "fresh" }));
+    await writeFile(
+      freshFile,
+      JSON.stringify({ todos: [], sessionId: "fresh" })
+    );
     const freshTime = new Date(Date.now() - 60 * 60 * 1000);
     await utimes(freshFile, freshTime, freshTime);
 
@@ -134,12 +144,16 @@ describe("stale todo cleanup", () => {
     const cutoff = Date.now() - 24 * 60 * 60 * 1000;
     const entries = await readdir(cleanupTestDir, { withFileTypes: true });
     for (const entry of entries) {
-      if (!entry.isFile()) continue;
+      if (!entry.isFile()) {
+        continue;
+      }
       const filePath = path.join(cleanupTestDir, entry.name);
       const fileStats = await stat(filePath);
       if (fileStats.mtimeMs < cutoff) {
         const { unlink } = await import("node:fs/promises");
-        await unlink(filePath).catch(() => {});
+        await unlink(filePath).catch(() => {
+          /* ignore */
+        });
       }
     }
 

--- a/packages/cea/src/tools/planning/todo-write.ts
+++ b/packages/cea/src/tools/planning/todo-write.ts
@@ -83,11 +83,15 @@ async function cleanupStaleTodos(todoDir: string): Promise<void> {
   try {
     const entries = await readdir(todoDir, { withFileTypes: true });
     for (const entry of entries) {
-      if (!entry.isFile()) continue;
+      if (!entry.isFile()) {
+        continue;
+      }
       const filePath = join(todoDir, entry.name);
       const fileStats = await stat(filePath);
       if (fileStats.mtimeMs < cutoff) {
-        await unlink(filePath).catch(() => {});
+        await unlink(filePath).catch(() => {
+          /* ignore */
+        });
       }
     }
   } catch {

--- a/packages/cea/src/tools/utils/execute/noninteractive-wrapper.test.ts
+++ b/packages/cea/src/tools/utils/execute/noninteractive-wrapper.test.ts
@@ -6,6 +6,8 @@ import {
 } from "./noninteractive-wrapper";
 
 const DUPLICATE_Y_FLAG = /-y.*-y/;
+const DASH_Y_RE = /-y/;
+const TRAILING_DASH_Y_RE = / -y$/;
 
 describe("wrapCommandNonInteractive", () => {
   describe("apt/apt-get commands", () => {
@@ -311,7 +313,7 @@ describe("compound command handling", () => {
       "apt-get update && apt-get install nginx"
     );
     expect(result.command).toBe("apt-get update && apt-get install nginx");
-    expect(result.command).not.toMatch(/-y/);
+    expect(result.command).not.toMatch(DASH_Y_RE);
   });
 
   it("does not append -y to pip install package && pip install other", () => {
@@ -326,7 +328,7 @@ describe("compound command handling", () => {
       "apt-get update || apt-get install nginx"
     );
     expect(result.command).toBe("apt-get update || apt-get install nginx");
-    expect(result.command).not.toMatch(/-y/);
+    expect(result.command).not.toMatch(DASH_Y_RE);
   });
 
   it("does not append suffix args to commands with ; separator", () => {
@@ -334,7 +336,7 @@ describe("compound command handling", () => {
       "apt-get update ; apt-get install nginx"
     );
     expect(result.command).toBe("apt-get update ; apt-get install nginx");
-    expect(result.command).not.toMatch(/-y/);
+    expect(result.command).not.toMatch(DASH_Y_RE);
   });
 
   it("does not append suffix args to piped commands", () => {
@@ -342,7 +344,7 @@ describe("compound command handling", () => {
       "apt-get install nginx | tee /tmp/log"
     );
     expect(result.command).toBe("apt-get install nginx | tee /tmp/log");
-    expect(result.command).not.toMatch(/-y/);
+    expect(result.command).not.toMatch(DASH_Y_RE);
   });
 
   it("still appends -y to simple apt-get install", () => {
@@ -352,6 +354,6 @@ describe("compound command handling", () => {
 
   it("hasFlag does not match -y inside single-quoted argument", () => {
     const result = wrapCommandNonInteractive("pip install 'package==-y'");
-    expect(result.command).not.toMatch(/ -y$/);
+    expect(result.command).not.toMatch(TRAILING_DASH_Y_RE);
   });
 });

--- a/packages/cea/src/tools/utils/execute/noninteractive-wrapper.ts
+++ b/packages/cea/src/tools/utils/execute/noninteractive-wrapper.ts
@@ -197,36 +197,59 @@ const TOOL_PATTERNS: ToolPattern[] = [
   },
 ];
 
-const WHITESPACE_SPLIT_PATTERN = /\s+/;
+const _WHITESPACE_SPLIT_PATTERN = /\s+/;
 
 function isCompoundCommand(command: string): boolean {
   let inSingle = false;
   let inDouble = false;
   for (let i = 0; i < command.length; i++) {
     const ch = command[i];
-    if (ch === "'" && !inDouble) { inSingle = !inSingle; continue; }
-    if (ch === '"' && !inSingle) { inDouble = !inDouble; continue; }
-    if (inSingle || inDouble) continue;
+    if (ch === "'" && !inDouble) {
+      inSingle = !inSingle;
+      continue;
+    }
+    if (ch === '"' && !inSingle) {
+      inDouble = !inDouble;
+      continue;
+    }
+    if (inSingle || inDouble) {
+      continue;
+    }
     const twoChar = command.slice(i, i + 2);
-    if (twoChar === '&&' || twoChar === '||') return true;
-    if (ch === ';' || ch === '|') return true;
+    if (twoChar === "&&" || twoChar === "||") {
+      return true;
+    }
+    if (ch === ";" || ch === "|") {
+      return true;
+    }
   }
   return false;
 }
 
 function hasFlag(command: string, flag: string): boolean {
   const tokens: string[] = [];
-  let current = '';
+  let current = "";
   let inSingle = false;
   let inDouble = false;
   for (const ch of command) {
-    if (ch === "'" && !inDouble) { inSingle = !inSingle; current += ch; }
-    else if (ch === '"' && !inSingle) { inDouble = !inDouble; current += ch; }
-    else if ((ch === ' ' || ch === '\t') && !inSingle && !inDouble) {
-      if (current) { tokens.push(current); current = ''; }
-    } else { current += ch; }
+    if (ch === "'" && !inDouble) {
+      inSingle = !inSingle;
+      current += ch;
+    } else if (ch === '"' && !inSingle) {
+      inDouble = !inDouble;
+      current += ch;
+    } else if ((ch === " " || ch === "\t") && !inSingle && !inDouble) {
+      if (current) {
+        tokens.push(current);
+        current = "";
+      }
+    } else {
+      current += ch;
+    }
   }
-  if (current) tokens.push(current);
+  if (current) {
+    tokens.push(current);
+  }
   return tokens.includes(flag);
 }
 
@@ -248,12 +271,14 @@ function insertArgsAfterCommand(
 }
 
 function appendArgs(command: string, args: string[]): string {
-  if (isCompoundCommand(command)) return command;
+  if (isCompoundCommand(command)) {
+    return command;
+  }
   const argsToAdd = args.filter((arg) => !hasFlag(command, arg));
   if (argsToAdd.length === 0) {
     return command;
   }
-  return `${command} ${argsToAdd.join(' ')}`;
+  return `${command} ${argsToAdd.join(" ")}`;
 }
 
 function getBaseEnv(): Record<string, string> {

--- a/packages/cea/src/tools/utils/execute/output-handler.test.ts
+++ b/packages/cea/src/tools/utils/execute/output-handler.test.ts
@@ -88,6 +88,7 @@ describe("truncateOutput", () => {
 
       // Verify file permissions are restrictive (owner only: 0o600)
       const stats = statSync(fullOutputPath);
+      // biome-ignore lint/suspicious/noBitwiseOperators: intentional file permission bitmask
       const mode = stats.mode & 0o777;
       expect(mode).toBe(0o600);
 

--- a/packages/cea/src/tools/utils/execute/process-manager.test.ts
+++ b/packages/cea/src/tools/utils/execute/process-manager.test.ts
@@ -200,7 +200,9 @@ describe("process-manager", () => {
 
     const pid = child.pid;
     expect(pid).toBeDefined();
-    if (!pid) throw new Error("Expected pid to be defined");
+    if (!pid) {
+      throw new Error("Expected pid to be defined");
+    }
 
     child.unref();
     await sleep(ABORT_DELAY_MS);
@@ -234,13 +236,18 @@ describe("process-manager", () => {
     resetProcessManagerForTesting();
 
     const controller = new AbortController();
-    const commandPromise = executeCommand("sleep 30", { signal: controller.signal });
+    const commandPromise = executeCommand("sleep 30", {
+      signal: controller.signal,
+    });
 
     // Let the process spawn and register in activeProcesses
     await sleep(10);
     const pids = getActiveProcessesForTesting();
     expect(pids.length).toBe(1);
-    const pid = pids[0]!;
+    const pid = pids[0];
+    if (pid === undefined) {
+      throw new Error("Expected pid");
+    }
 
     // Abort — triggers killProcessTree which sets a SIGKILL timer
     controller.abort();

--- a/packages/cea/src/tools/utils/hashline/autocorrect-replacement-lines.ts
+++ b/packages/cea/src/tools/utils/hashline/autocorrect-replacement-lines.ts
@@ -25,7 +25,6 @@ function leadingWhitespace(text: string): string {
   return match ? match[0] : "";
 }
 
-// biome-ignore lint/complexity/noExcessiveCognitiveComplexity: line-wrapping restoration algorithm
 export function restoreOldWrappedLines(
   originalLines: string[],
   replacementLines: string[]

--- a/packages/cea/src/tools/utils/hashline/edit-operations.ts
+++ b/packages/cea/src/tools/utils/hashline/edit-operations.ts
@@ -17,9 +17,13 @@ import { validateLineRefs } from "./validation";
 
 /** Compare two string arrays element-by-element. O(n) with early exit. */
 function arraysEqual(a: string[], b: string[]): boolean {
-  if (a.length !== b.length) return false;
+  if (a.length !== b.length) {
+    return false;
+  }
   for (let i = 0; i < a.length; i++) {
-    if (a[i] !== b[i]) return false;
+    if (a[i] !== b[i]) {
+      return false;
+    }
   }
   return true;
 }
@@ -30,7 +34,6 @@ export interface HashlineApplyReport {
   noopEdits: number;
 }
 
-// biome-ignore lint/complexity/noExcessiveCognitiveComplexity: core edit application logic
 export function applyHashlineEditsWithReport(
   content: string,
   edits: HashlineEdit[]

--- a/packages/cea/src/tools/utils/safety-utils.ts
+++ b/packages/cea/src/tools/utils/safety-utils.ts
@@ -696,7 +696,6 @@ const checkPathTraversalGuard: FileWriteGuard = ({
  * Rejects operations when the project root is the system root (/).
  * This prevents accidental modification of system files when cwd is /.
  */
-// biome-ignore lint/correctness/noUnusedVariables: Reserved for future use
 const checkRootDirectoryGuard: FileWriteGuard = ({ rootDir }) => {
   if (rootDir === "/" || rootDir === "\\") {
     return {
@@ -715,7 +714,6 @@ const checkRootDirectoryGuard: FileWriteGuard = ({ rootDir }) => {
  * but only when they are outside the project root.
  * This prevents access to system files while allowing test directories in /tmp.
  */
-// biome-ignore lint/correctness/noUnusedVariables: Reserved for future use
 const checkSensitivePathsGuard: FileWriteGuard = ({
   filePath,
   resolvedFilePath,
@@ -753,7 +751,6 @@ const checkSensitivePathsGuard: FileWriteGuard = ({
  * Checks the raw path for '..' segments before resolution.
  * Catches attempts to traverse upward that might be obscured.
  */
-// biome-ignore lint/correctness/noUnusedVariables: Reserved for future use
 const checkPathTraversalSegmentsGuard: FileWriteGuard = ({
   filePath,
   rootDir,


### PR DESCRIPTION
## Summary

Fix both CI failure root causes on the main branch:

### 1. Changeset Package Name Mismatch
- All 7 changeset files referencing `@ai-sdk-tool/cea` have been corrected to `plugsuits` (the actual package name in `packages/cea/package.json`)
- This fixes the Release workflow error: `Found changeset for package @ai-sdk-tool/cea which is not in the workspace`

### 2. Biome Lint/Format Compliance
- **Formatting**: Fixed import ordering, extra blank lines, line wrapping, single-line callbacks expanded to multi-line
- **Lint errors resolved**: `useTopLevelRegex` (moved regex to module scope), `noNonNullAssertion` (replaced with undefined checks), `noEmptyBlockStatements` (added comments), `noExportedImports` (use `export from`), `noUselessContinue`, `useBlockStatements`, `noBitwiseOperators` (suppressed for permission mask)
- **Stale suppressions removed**: Cleaned up 4 unused `biome-ignore` comments
- **Config**: Set `noExcessiveCognitiveComplexity` threshold to 30 in `biome.jsonc` for complex but intentional functions

### Verification
- `bun run check` — passes (0 errors)
- `bun run typecheck` — passes
- `bun test packages/cea/src` — 490 pass, 2 pre-existing shell-detection failures
- `bun test packages/harness/src` — 52 pass, 0 fail

### Files Changed
- 7 changeset files (package name fix)
- `biome.jsonc` (complexity threshold)
- 25 source/test files (lint + format fixes)

Closes CI failures on main branch.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes CI on main by correcting Changeset package names and making the codebase pass Biome lint/format rules. Release and check workflows now run cleanly.

- **Bug Fixes**
  - Changesets: renamed `@ai-sdk-tool/cea` to `plugsuits` in 7 files to match the workspace and fix the release error.
  - Biome compliance: standardized imports/spacing/wrapping, fixed rule violations (e.g., top-level regex, non-null assertions, empty blocks, exported imports, block statements), removed stale `biome-ignore`s, and set cognitive complexity max to 30 in `biome.jsonc`.
  - Verification: `bun run check` and `bun run typecheck` pass; tests pass across packages (existing known failures unchanged).

<sup>Written for commit af6797d9bb1ce1d9cc70b7268506e3e8f4539cc1. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

