### PR TITLE
chore: publish @ai-sdk-tool/headless and @ai-sdk-tool/tui to npm

### DIFF
--- a/.changeset/publish-headless-tui.md
+++ b/.changeset/publish-headless-tui.md
@@ -1,0 +1,10 @@
+---
+"@ai-sdk-tool/headless": major
+"@ai-sdk-tool/tui": major
+"plugsuits": patch
+---
+
+fix: publish @ai-sdk-tool/headless and @ai-sdk-tool/tui to npm
+
+Initial major release of headless and tui packages to npm registry.
+Republish plugsuits with corrected dependency versions.


### PR DESCRIPTION
## Summary
- Adds changeset to bump `@ai-sdk-tool/headless` and `@ai-sdk-tool/tui` from `0.1.0` to `1.0.0` (major)
- Republishes `plugsuits` with corrected dependency versions

## Context
`plugsuits@2.1.0` on npm depends on `@ai-sdk-tool/headless@1.0.0` and `@ai-sdk-tool/tui@1.0.0`, but only `0.1.0` was published. This makes `plugsuits@2.1.0` uninstallable.

Merging this PR will trigger the changeset CI to version-bump and publish the missing packages.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a changeset to publish `@ai-sdk-tool/headless` and `@ai-sdk-tool/tui` at 1.0.0 and republish `plugsuits` with corrected dependency versions. Fixes the install issue where `plugsuits@2.1.0` referenced unpublished packages.

<sup>Written for commit 7d6185198bb2733fab2da84434dfb836e915c5a7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

