### PR TITLE
fix(cea): read CLI version from package.json instead of hardcoded value

### DIFF
--- a/packages/cea/src/entrypoints/main.ts
+++ b/packages/cea/src/entrypoints/main.ts
@@ -1,5 +1,6 @@
-import { mkdirSync } from "node:fs";
-import { join } from "node:path";
+import { mkdirSync, readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
 import {
   CheckpointHistory,
   type Command,
@@ -428,10 +429,15 @@ process.once("unhandledRejection", (reason: unknown) => {
   exitWithCleanup(1);
 });
 
+const __cliDirname = dirname(fileURLToPath(import.meta.url));
+const __cliVersion: string = JSON.parse(
+  readFileSync(join(__cliDirname, "../../package.json"), "utf-8")
+).version;
+
 const mainCommand = defineCommand({
   meta: {
     name: "plugsuits",
-    version: "2.0.0",
+    version: __cliVersion,
     description: "Code Editing Agent",
   },
   args: {


### PR DESCRIPTION
## Summary

- `pss --version` was returning `2.0.0` even after installing `plugsuits@latest` (2.2.0) because the version was hardcoded in `defineCommand` meta
- Now reads version dynamically from `package.json` at runtime using `readFileSync` + `import.meta.url`, so it stays in sync across releases automatically

## Changes

- `packages/cea/src/entrypoints/main.ts`: Replace hardcoded `"2.0.0"` with dynamic `package.json` read

## Verification

- Build passes (`pnpm run build`)
- `node packages/cea/cli.js --version` → `2.2.0` ✓
- Path resolution is safe across dev (`src/entrypoints/`), build (`dist/entrypoints/`), and global npm install environments

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Read the CLI version from `package.json` instead of a hardcoded string, so `pss --version` matches the installed `plugsuits` release. Uses `import.meta.url` to resolve the package root at runtime.

<sup>Written for commit 9b3c24d7bc5fc8c999951d2fcf7f7660f457132b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

