### PR TITLE
feat(harness): add MCP client integration

### DIFF
--- a/.changeset/mcp-integration-dx.md
+++ b/.changeset/mcp-integration-dx.md
@@ -1,0 +1,16 @@
+---
+"@ai-sdk-tool/harness": patch
+"plugsuits": patch
+"@plugsuits/minimal-agent": patch
+---
+
+Add MCP (Model Context Protocol) client integration and improve developer experience
+
+- `createAgent()` now accepts an `mcp` option for automatic MCP tool loading
+- `createAgent()` is now async and returns `Promise<Agent>`
+- `Agent.close()` method added for MCP connection cleanup (no-op when no MCP configured)
+- `MCPOption` supports four forms: `true` (load from `.mcp.json`), `MCPServerConfig[]` (inline servers), `{ config, servers }` (both), or a pre-initialized `MCPManager` instance
+- MCPManager caching with reference counting — same config reuses existing connections
+- Inline server arrays (`MCPServerConfig[]`) now correctly passed to MCPManager
+- `MCPManagerOptions.servers` added for programmatic server injection
+- Minimal agent wired with DuckDuckGo search MCP server

--- a/packages/cea/src/agent.ts
+++ b/packages/cea/src/agent.ts
@@ -804,7 +804,7 @@ ${buildTodoContinuationPrompt(incompleteTodos)}`;
       );
     }
 
-    const agent = createAgent({
+    const agent = await createAgent({
       model,
       tools: this.toolRegistry,
       instructions: await this.getInstructions(),
@@ -836,7 +836,7 @@ ${buildTodoContinuationPrompt(incompleteTodos)}`;
     const { model, providerOptions } = this.buildModel("off");
     const preparedMessages = probeMessages;
 
-    const agent = createAgent({
+    const agent = await createAgent({
       model,
       tools: this.toolRegistry,
       instructions: await this.getInstructions(),

--- a/packages/cea/src/entrypoints/main.ts
+++ b/packages/cea/src/entrypoints/main.ts
@@ -9,6 +9,7 @@ import {
   CompactionCircuitBreaker,
   type CompactionResult,
   estimateTokens,
+  MCPManager,
   PostCompactRestorer,
   parseCommand,
   type RunnableAgent,
@@ -230,6 +231,7 @@ const unregisterSkillLoadListener = registerSkillLoadListener((skill) => {
     type: "skill",
   });
 });
+let mcpManager: MCPManager | undefined;
 const trackedReadToolResultIds = new Set<string>();
 
 const toRecord = (value: unknown): Record<string, unknown> | null => {
@@ -574,6 +576,7 @@ const createCliCommands = (): Command[] => {
 };
 
 const exitWithCleanup = (code: number): never => {
+  mcpManager?.close().catch(() => undefined);
   cleanup(true);
   process.exit(code);
 };
@@ -596,6 +599,7 @@ const getAtifOutputPath = (args: { atif?: boolean }): string | undefined => {
 };
 
 process.once("exit", () => {
+  mcpManager?.close().catch(() => undefined);
   unregisterSkillLoadListener();
   cleanup();
 });
@@ -655,6 +659,19 @@ const mainCommand = defineCommand({
   async run({ args }) {
     validateProviderConfig();
     await initializeTools();
+    mcpManager = new MCPManager({
+      onError: (server, error) => {
+        console.warn(`[MCP] Server "${server}" failed:`, error);
+      },
+    });
+    await mcpManager.init();
+    const mcpTools = mcpManager.tools();
+    if (Object.keys(mcpTools).length > 0) {
+      agentManager.setTools({ ...agentManager.getTools(), ...mcpTools });
+      console.log(
+        `[MCP] Loaded ${Object.keys(mcpTools).length} tools from MCP servers`
+      );
+    }
     setSpinnerOutputEnabled(false);
     sessionManager.initialize();
     applyCurrentSessionToRuntime();

--- a/packages/cea/src/entrypoints/main.ts
+++ b/packages/cea/src/entrypoints/main.ts
@@ -668,7 +668,7 @@ const mainCommand = defineCommand({
     const mcpTools = mcpManager.tools();
     if (Object.keys(mcpTools).length > 0) {
       agentManager.setTools({ ...agentManager.getTools(), ...mcpTools });
-      console.log(
+      console.warn(
         `[MCP] Loaded ${Object.keys(mcpTools).length} tools from MCP servers`
       );
     }

--- a/packages/cea/src/entrypoints/main.ts
+++ b/packages/cea/src/entrypoints/main.ts
@@ -583,7 +583,7 @@ const createCliCommands = (): Command[] => {
 const exitWithCleanup = async (code: number): Promise<never> => {
   if (mcpManager) {
     await Promise.race([
-      mcpManager.close(),
+      mcpManager.close().catch(() => undefined),
       new Promise((resolve) => setTimeout(resolve, 1000)),
     ]);
   }
@@ -794,7 +794,7 @@ const mainCommand = defineCommand({
           type: "error",
           error: error instanceof Error ? error.message : String(error),
         });
-        exitWithCleanup(1);
+        await exitWithCleanup(1);
       }
 
       cleanup();

--- a/packages/cea/src/entrypoints/main.ts
+++ b/packages/cea/src/entrypoints/main.ts
@@ -10,6 +10,7 @@ import {
   type CompactionResult,
   estimateTokens,
   MCPManager,
+  mergeMCPTools,
   PostCompactRestorer,
   parseCommand,
   type RunnableAgent,
@@ -626,6 +627,36 @@ process.once("unhandledRejection", (reason: unknown) => {
   exitWithCleanup(1);
 });
 
+const initializeMCPTools = async (): Promise<void> => {
+  mcpManager = new MCPManager({
+    onError: (server, error) => {
+      console.warn(`[MCP] Server "${server}" failed:`, error);
+    },
+  });
+  await mcpManager.init();
+  const mcpTools = mcpManager.tools();
+  if (Object.keys(mcpTools).length === 0) {
+    return;
+  }
+
+  const localTools = agentManager.getTools();
+  const { tools: mergedTools, conflicts } = mergeMCPTools({
+    localTools,
+    mcpTools: { "mcp-servers": mcpTools },
+    onConflict: (conflict) => {
+      console.warn(
+        `[MCP] Tool name conflict: "${conflict.toolName}" — renamed to avoid collision with local tools`
+      );
+    },
+  });
+  agentManager.setTools(mergedTools as typeof localTools);
+  const addedCount =
+    Object.keys(mergedTools).length - Object.keys(localTools).length;
+  console.warn(
+    `[MCP] Loaded ${addedCount} MCP tools from MCP servers${conflicts.length > 0 ? `, ${conflicts.length} conflict(s) resolved` : ""}`
+  );
+};
+
 const __cliDirname = dirname(fileURLToPath(import.meta.url));
 const __cliVersion: string = JSON.parse(
   readFileSync(join(__cliDirname, "../../package.json"), "utf-8")
@@ -659,19 +690,7 @@ const mainCommand = defineCommand({
   async run({ args }) {
     validateProviderConfig();
     await initializeTools();
-    mcpManager = new MCPManager({
-      onError: (server, error) => {
-        console.warn(`[MCP] Server "${server}" failed:`, error);
-      },
-    });
-    await mcpManager.init();
-    const mcpTools = mcpManager.tools();
-    if (Object.keys(mcpTools).length > 0) {
-      agentManager.setTools({ ...agentManager.getTools(), ...mcpTools });
-      console.warn(
-        `[MCP] Loaded ${Object.keys(mcpTools).length} tools from MCP servers`
-      );
-    }
+    await initializeMCPTools();
     setSpinnerOutputEnabled(false);
     sessionManager.initialize();
     applyCurrentSessionToRuntime();

--- a/packages/cea/src/entrypoints/main.ts
+++ b/packages/cea/src/entrypoints/main.ts
@@ -9,6 +9,7 @@ import {
   CompactionCircuitBreaker,
   type CompactionResult,
   estimateTokens,
+  estimateToolSchemasTokens,
   MCPManager,
   mergeMCPTools,
   PostCompactRestorer,
@@ -525,6 +526,9 @@ const updateCompactionForCurrentModel = async (): Promise<void> => {
   );
   const instructions = await agentManager.getInstructions();
   messageHistory.setSystemPromptTokens(estimateTokens(instructions));
+  messageHistory.setToolSchemasTokens(
+    estimateToolSchemasTokens(agentManager.getTools())
+  );
 };
 
 const applyCurrentSessionToRuntime = (): void => {

--- a/packages/cea/src/entrypoints/main.ts
+++ b/packages/cea/src/entrypoints/main.ts
@@ -609,7 +609,6 @@ const getAtifOutputPath = (args: { atif?: boolean }): string | undefined => {
 };
 
 process.once("exit", () => {
-  mcpManager?.close().catch(() => undefined);
   unregisterSkillLoadListener();
   cleanup();
 });

--- a/packages/cea/src/entrypoints/main.ts
+++ b/packages/cea/src/entrypoints/main.ts
@@ -576,8 +576,13 @@ const createCliCommands = (): Command[] => {
   });
 };
 
-const exitWithCleanup = (code: number): never => {
-  mcpManager?.close().catch(() => undefined);
+const exitWithCleanup = async (code: number): Promise<never> => {
+  if (mcpManager) {
+    await Promise.race([
+      mcpManager.close(),
+      new Promise((resolve) => setTimeout(resolve, 1000)),
+    ]);
+  }
   cleanup(true);
   process.exit(code);
 };
@@ -588,7 +593,7 @@ const requestSignalShutdown = (code: number): void => {
   }
   signalShutdownRequested = true;
   requestedProcessExitCode = code;
-  exitWithCleanup(code);
+  exitWithCleanup(code).catch(() => process.exit(code));
 };
 
 const getAtifOutputPath = (args: { atif?: boolean }): string | undefined => {
@@ -619,12 +624,12 @@ process.once("SIGQUIT", () => {
 
 process.once("uncaughtException", (error: unknown) => {
   console.error("Fatal error:", error);
-  exitWithCleanup(1);
+  exitWithCleanup(1).catch(() => process.exit(1));
 });
 
 process.once("unhandledRejection", (reason: unknown) => {
   console.error("Unhandled rejection:", reason);
-  exitWithCleanup(1);
+  exitWithCleanup(1).catch(() => process.exit(1));
 });
 
 const initializeMCPTools = async (): Promise<void> => {
@@ -634,15 +639,15 @@ const initializeMCPTools = async (): Promise<void> => {
     },
   });
   await mcpManager.init();
-  const mcpTools = mcpManager.tools();
-  if (Object.keys(mcpTools).length === 0) {
+  const perServerTools = mcpManager.toolsByServer();
+  if (Object.keys(perServerTools).length === 0) {
     return;
   }
 
   const localTools = agentManager.getTools();
   const { tools: mergedTools, conflicts } = mergeMCPTools({
     localTools,
-    mcpTools: { "mcp-servers": mcpTools },
+    mcpTools: perServerTools,
     onConflict: (conflict) => {
       console.warn(
         `[MCP] Tool name conflict: "${conflict.toolName}" — renamed to avoid collision with local tools`

--- a/packages/harness/package.json
+++ b/packages/harness/package.json
@@ -29,6 +29,7 @@
     "test": "vitest run src"
   },
   "dependencies": {
+    "@ai-sdk/mcp": "^1.0.32",
     "@ai-sdk/provider": "^3.0.8",
     "@t3-oss/env-core": "^0.13.10",
     "ai": "^6.0.116",

--- a/packages/harness/src/agent.test.ts
+++ b/packages/harness/src/agent.test.ts
@@ -1,8 +1,9 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { createAgent } from "./agent";
+import { clearMCPCache } from "./mcp-init.js";
 import type { AgentConfig } from "./types";
 
-const { streamTextMock } = vi.hoisted(() => {
+const { resolveMCPOptionMock, streamTextMock } = vi.hoisted(() => {
   const mock = vi.fn(() => {
     const fullStream: AsyncIterable<{ finishReason: string; type: string }> = {
       [Symbol.asyncIterator]() {
@@ -30,7 +31,13 @@ const { streamTextMock } = vi.hoisted(() => {
     };
   });
 
-  return { streamTextMock: mock };
+  return {
+    resolveMCPOptionMock: vi.fn().mockResolvedValue({
+      close: vi.fn().mockResolvedValue(undefined),
+      tools: { mcp_tool: {} },
+    }),
+    streamTextMock: mock,
+  };
 });
 
 vi.mock("ai", () => {
@@ -40,25 +47,34 @@ vi.mock("ai", () => {
   };
 });
 
+vi.mock("./mcp-init.js", () => ({
+  clearMCPCache: vi.fn(),
+  resolveMCPOption: resolveMCPOptionMock,
+}));
+
 function createMockModel(): AgentConfig["model"] {
   return {} as AgentConfig["model"];
 }
 
 describe("createAgent", () => {
   beforeEach(() => {
+    clearMCPCache();
+    resolveMCPOptionMock.mockClear();
     streamTextMock.mockClear();
   });
 
-  it("returns an agent with config and stream method", () => {
+  it("returns an agent with config, stream method, and close method", async () => {
     const model = createMockModel();
-    const agent = createAgent({ model });
+    const agent = await createAgent({ model });
 
     expect(agent).toHaveProperty("config");
+    expect(agent).toHaveProperty("close");
     expect(agent).toHaveProperty("stream");
+    expect(typeof agent.close).toBe("function");
     expect(typeof agent.stream).toBe("function");
   });
 
-  it("preserves provided config values", () => {
+  it("preserves provided config values", async () => {
     const model = createMockModel();
     const config: AgentConfig = {
       model,
@@ -66,21 +82,21 @@ describe("createAgent", () => {
       maxStepsPerTurn: 5,
     };
 
-    const agent = createAgent(config);
+    const agent = await createAgent(config);
 
     expect(agent.config.model).toBe(model);
     expect(agent.config.instructions).toBe("You are a harness test agent.");
     expect(agent.config.maxStepsPerTurn).toBe(5);
   });
 
-  it("keeps maxStepsPerTurn undefined when omitted", () => {
-    const agent = createAgent({ model: createMockModel() });
+  it("keeps maxStepsPerTurn undefined when omitted", async () => {
+    const agent = await createAgent({ model: createMockModel() });
 
     expect(agent.config.maxStepsPerTurn).toBeUndefined();
   });
 
-  it("passes temperature and seed through to streamText", () => {
-    const agent = createAgent({ model: createMockModel() });
+  it("passes temperature and seed through to streamText", async () => {
+    const agent = await createAgent({ model: createMockModel() });
 
     agent.stream({
       messages: [],
@@ -94,6 +110,36 @@ describe("createAgent", () => {
         temperature: 0,
       })
     );
+  });
+
+  it("agent.close is a no-op when MCP is not configured", async () => {
+    const agent = await createAgent({ model: createMockModel() });
+
+    await expect(agent.close()).resolves.toBeUndefined();
+  });
+
+  it("calls resolveMCPOption when MCP is provided", async () => {
+    const model = createMockModel();
+
+    await createAgent({ model, mcp: true });
+
+    expect(resolveMCPOptionMock).toHaveBeenCalledWith(true, {});
+  });
+
+  it("returns an agent with MCP-resolved tools and close handler", async () => {
+    const closeMock = vi.fn().mockResolvedValue(undefined);
+    const mcpTools = { mcp_tool: {} };
+    resolveMCPOptionMock.mockResolvedValueOnce({
+      close: closeMock,
+      tools: mcpTools,
+    });
+
+    const agent = await createAgent({ model: createMockModel(), mcp: true });
+
+    expect(agent.config.tools).toBe(mcpTools);
+
+    await agent.close();
+    expect(closeMock).toHaveBeenCalledTimes(1);
   });
 
   it("silences unhandled rejections when stream result promises are not awaited", async () => {
@@ -138,7 +184,7 @@ describe("createAgent", () => {
     process.on("unhandledRejection", handler);
 
     try {
-      const agent = createAgent({ model: createMockModel() });
+      const agent = await createAgent({ model: createMockModel() });
       const result = agent.stream({ messages: [] });
 
       finishReasonDeferred.reject(rejectionError);
@@ -177,16 +223,21 @@ describe("createAgent", () => {
           },
         };
 
-      const streamResult: Record<string, unknown> = {
+      const streamResult = {
         finishReason: Promise.resolve("stop"),
         fullStream: emptyStream,
         response: Promise.resolve({ messages: [] }),
         totalUsage: Promise.resolve(undefined),
         usage: Promise.resolve(undefined),
-      };
+      } as ReturnType<typeof streamTextMock>;
       let rejectTarget: (error: unknown) => void = () => undefined;
-      streamResult[targetField] = new Promise<never>((_, reject) => {
-        rejectTarget = reject;
+      Object.defineProperty(streamResult, targetField, {
+        configurable: true,
+        enumerable: true,
+        value: new Promise<never>((_, reject) => {
+          rejectTarget = reject;
+        }),
+        writable: true,
       });
 
       streamTextMock.mockImplementationOnce(() => streamResult);
@@ -198,7 +249,7 @@ describe("createAgent", () => {
       process.on("unhandledRejection", handler);
 
       try {
-        const agent = createAgent({ model: createMockModel() });
+        const agent = await createAgent({ model: createMockModel() });
         const result = agent.stream({ messages: [] });
 
         rejectTarget(rejectionError);

--- a/packages/harness/src/agent.ts
+++ b/packages/harness/src/agent.ts
@@ -20,7 +20,7 @@ import type {
  *
  * @example
  * ```typescript
- * const agent = createAgent({
+ * const agent = await createAgent({
  *   model: openai('gpt-4o'),
  *   instructions: 'You are a helpful assistant.',
  *   tools: { get_time: tool({ ... }) },

--- a/packages/harness/src/agent.ts
+++ b/packages/harness/src/agent.ts
@@ -4,13 +4,13 @@
  */
 
 import { stepCountIs, streamText } from "ai";
+import { resolveMCPOption } from "./mcp-init.js";
 import type {
   Agent,
   AgentConfig,
   AgentStreamOptions,
   AgentStreamResult,
 } from "./types";
-import { resolveMCPOption } from "./mcp-init.js";
 
 /**
  * Creates an {@link Agent} instance that wraps a Vercel AI SDK `streamText` call.

--- a/packages/harness/src/agent.ts
+++ b/packages/harness/src/agent.ts
@@ -10,6 +10,7 @@ import type {
   AgentStreamOptions,
   AgentStreamResult,
 } from "./types";
+import { resolveMCPOption } from "./mcp-init.js";
 
 /**
  * Creates an {@link Agent} instance that wraps a Vercel AI SDK `streamText` call.
@@ -26,9 +27,22 @@ import type {
  * });
  * ```
  */
-export function createAgent(config: AgentConfig): Agent {
+export async function createAgent(config: AgentConfig): Promise<Agent> {
+  let mergedTools = config.tools;
+  let closeFn: () => Promise<void> = async () => undefined;
+
+  if (config.mcp !== undefined) {
+    const resolved = await resolveMCPOption(config.mcp, config.tools ?? {});
+    mergedTools = resolved.tools;
+    closeFn = resolved.close;
+  }
+
+  const effectiveConfig: AgentConfig =
+    mergedTools !== config.tools ? { ...config, tools: mergedTools } : config;
+
   return {
-    config,
+    config: effectiveConfig,
+    close: closeFn,
     /**
      * Initiates a single streaming turn with the given messages.
      * Returns a result object with `fullStream`, `finishReason`, and `response`.
@@ -36,28 +50,26 @@ export function createAgent(config: AgentConfig): Agent {
     stream(opts: AgentStreamOptions): AgentStreamResult {
       const system =
         opts.system ??
-        (typeof config.instructions === "string"
-          ? config.instructions
+        (typeof effectiveConfig.instructions === "string"
+          ? effectiveConfig.instructions
           : undefined);
 
       const result = streamText({
-        model: config.model,
-        tools: config.tools,
+        model: effectiveConfig.model,
+        tools: effectiveConfig.tools,
         system,
         messages: opts.messages,
         providerOptions: opts.providerOptions,
         maxOutputTokens: opts.maxOutputTokens,
         seed: opts.seed,
-        stopWhen: stepCountIs(config.maxStepsPerTurn ?? 1),
+        stopWhen: stepCountIs(effectiveConfig.maxStepsPerTurn ?? 1),
         temperature: opts.temperature,
         abortSignal: opts.abortSignal,
-        experimental_repairToolCall: config.experimental_repairToolCall,
+        experimental_repairToolCall:
+          effectiveConfig.experimental_repairToolCall,
       });
 
-      const finishReason = result.finishReason;
-      const response = result.response;
-      const usage = result.usage;
-      const totalUsage = result.totalUsage;
+      const { finishReason, response, usage, totalUsage } = result;
 
       const swallow = () => undefined;
       finishReason.then(undefined, swallow);

--- a/packages/harness/src/checkpoint-history.ts
+++ b/packages/harness/src/checkpoint-history.ts
@@ -869,7 +869,10 @@ export class CheckpointHistory {
     this.revision += 1;
     this.messageRevision += 1;
 
-    const tokensAfter = this.getEstimatedTokens();
+    const tokensAfter =
+      this.getEstimatedTokens() +
+      this.systemPromptTokens +
+      this.toolSchemasTokens;
     const effectiveness = this.evaluateCompactionAcceptance({
       contextLimit: this.compactionConfig.contextLimit,
       tokensAfter,
@@ -2204,7 +2207,10 @@ export class CheckpointHistory {
     this.revision += 1;
     this.messageRevision += 1;
 
-    const tokensAfter = this.getEstimatedTokens();
+    const tokensAfter =
+      this.getEstimatedTokens() +
+      this.systemPromptTokens +
+      this.toolSchemasTokens;
     const pruneEffectiveness = this.evaluateCompactionAcceptance({
       contextLimit,
       tokensAfter,
@@ -2337,7 +2343,10 @@ export class CheckpointHistory {
     this.revision += 1;
     this.messageRevision += 1;
 
-    const tokensAfter = this.getEstimatedTokens();
+    const tokensAfter =
+      this.getEstimatedTokens() +
+      this.systemPromptTokens +
+      this.toolSchemasTokens;
     const effectiveness = this.evaluateCompactionAcceptance({
       contextLimit,
       tokensAfter,

--- a/packages/harness/src/checkpoint-history.ts
+++ b/packages/harness/src/checkpoint-history.ts
@@ -308,6 +308,7 @@ export class CheckpointHistory {
   private recoveryInProgress = false;
   private contextLimit = 0;
   private systemPromptTokens = 0;
+  private toolSchemasTokens = 0;
   private revision = 0;
   // message-only revision: bumped by add/compact/prune/truncate/clear, NOT metadata ops
   private messageRevision = 0;
@@ -515,6 +516,19 @@ export class CheckpointHistory {
     return this.systemPromptTokens;
   }
 
+  setToolSchemasTokens(tokens: number): void {
+    const prev = this.toolSchemasTokens;
+    this.toolSchemasTokens = tokens;
+    if (prev !== tokens && this.actualUsage) {
+      this.actualUsage = null;
+    }
+    this.revision += 1;
+  }
+
+  getToolSchemasTokens(): number {
+    return this.toolSchemasTokens;
+  }
+
   isCompactionEnabled(): boolean {
     return this.compactionConfig.enabled ?? false;
   }
@@ -646,7 +660,9 @@ export class CheckpointHistory {
         messagesForLLM.reduce(
           (total, message) => total + estimateMessageTokens(message),
           0
-        ) + this.systemPromptTokens;
+        ) +
+        this.systemPromptTokens +
+        this.toolSchemasTokens;
     }
 
     return (
@@ -1423,7 +1439,10 @@ export class CheckpointHistory {
   }
 
   private refreshEstimatedUsage(): void {
-    const estimated = this.getEstimatedTokens() + this.systemPromptTokens;
+    const estimated =
+      this.getEstimatedTokens() +
+      this.systemPromptTokens +
+      this.toolSchemasTokens;
     this.actualUsage = {
       inputTokens: estimated,
       outputTokens: 0,
@@ -1617,7 +1636,11 @@ export class CheckpointHistory {
     if (this.actualUsage) {
       return this.actualUsage.inputTokens;
     }
-    return this.getEstimatedTokens() + this.systemPromptTokens;
+    return (
+      this.getEstimatedTokens() +
+      this.systemPromptTokens +
+      this.toolSchemasTokens
+    );
   }
 
   private getActiveContextLimit(): number {

--- a/packages/harness/src/checkpoint-history.ts
+++ b/packages/harness/src/checkpoint-history.ts
@@ -708,7 +708,10 @@ export class CheckpointHistory {
       };
     }
 
-    const tokensBefore = this.getEstimatedTokens();
+    const tokensBefore =
+      this.getEstimatedTokens() +
+      this.systemPromptTokens +
+      this.toolSchemasTokens;
     const summaryIndex = this.summaryMessageId
       ? this.messages.findIndex(
           (message) => message.id === this.summaryMessageId

--- a/packages/harness/src/index.ts
+++ b/packages/harness/src/index.ts
@@ -154,7 +154,12 @@ export type { SkillInfo, SkillsConfig } from "./skills";
 export { SkillsEngine } from "./skills";
 export type { TodoConfig, TodoItem } from "./todo-continuation";
 export { TodoContinuation } from "./todo-continuation";
-export { estimateTokens, extractMessageText } from "./token-utils";
+export {
+  estimateMessageTokens,
+  estimateTokens,
+  estimateToolSchemasTokens,
+  extractMessageText,
+} from "./token-utils";
 export {
   normalizeFinishReason,
   shouldContinueManualToolLoop,

--- a/packages/harness/src/index.ts
+++ b/packages/harness/src/index.ts
@@ -99,6 +99,20 @@ export type { ContinuationMessageData } from "./continuation";
 export { createContinuationMessage, getContinuationText } from "./continuation";
 export { env as harnessEnv } from "./env";
 export { runAgentLoop } from "./loop";
+export { isRemoteConfig, isStdioConfig, loadMCPConfig } from "./mcp-config";
+// MCP integration
+export { MCPManager } from "./mcp-manager";
+export type { MergeOptions, ToolConflict } from "./mcp-tool-merger";
+export { mergeMCPTools, sanitizeServerName } from "./mcp-tool-merger";
+export type {
+  MCPConfigFile,
+  MCPManagerOptions,
+  MCPRemoteServerConfig,
+  MCPServerConfig,
+  MCPServerStatus,
+  MCPStdioServerConfig,
+  MCPToolMergeResult,
+} from "./mcp-types";
 export { CHAT_MEMORY_PRESET, CODE_MEMORY_PRESET } from "./memory-presets";
 export type { MemoryStore } from "./memory-store";
 export { FileMemoryStore, InMemoryStore } from "./memory-store";
@@ -152,18 +166,4 @@ export type {
   PruningConfig,
 } from "./tool-pruning";
 export { progressivePrune, pruneToolOutputs } from "./tool-pruning";
-// MCP integration
-export { MCPManager } from "./mcp-manager";
-export { loadMCPConfig, isStdioConfig, isRemoteConfig } from "./mcp-config";
-export { mergeMCPTools, sanitizeServerName } from "./mcp-tool-merger";
-export type {
-  MCPConfigFile,
-  MCPManagerOptions,
-  MCPRemoteServerConfig,
-  MCPServerConfig,
-  MCPServerStatus,
-  MCPStdioServerConfig,
-  MCPToolMergeResult,
-} from "./mcp-types";
-export type { MergeOptions, ToolConflict } from "./mcp-tool-merger";
 export type * from "./types";

--- a/packages/harness/src/index.ts
+++ b/packages/harness/src/index.ts
@@ -152,4 +152,18 @@ export type {
   PruningConfig,
 } from "./tool-pruning";
 export { progressivePrune, pruneToolOutputs } from "./tool-pruning";
+// MCP integration
+export { MCPManager } from "./mcp-manager";
+export { loadMCPConfig, isStdioConfig, isRemoteConfig } from "./mcp-config";
+export { mergeMCPTools, sanitizeServerName } from "./mcp-tool-merger";
+export type {
+  MCPConfigFile,
+  MCPManagerOptions,
+  MCPRemoteServerConfig,
+  MCPServerConfig,
+  MCPServerStatus,
+  MCPStdioServerConfig,
+  MCPToolMergeResult,
+} from "./mcp-types";
+export type { MergeOptions, ToolConflict } from "./mcp-tool-merger";
 export type * from "./types";

--- a/packages/harness/src/mcp-config.test.ts
+++ b/packages/harness/src/mcp-config.test.ts
@@ -166,7 +166,7 @@ describe("loadMCPConfig", () => {
     await expect(loadMCPConfig()).rejects.toThrow(INVALID_CONFIG_ERROR_PATTERN);
   });
 
-  it("ignores unknown extra fields at the root and server level", async () => {
+  it("preserves unknown root fields while stripping unknown server fields", async () => {
     const configWithExtras = {
       mcpServers: {
         filesystem: {
@@ -192,6 +192,28 @@ describe("loadMCPConfig", () => {
       version: 1,
     });
     expect(result.mcpServers.filesystem).not.toHaveProperty("extraField");
+  });
+
+  it("accepts mixed stdio and remote fields by stripping the non-matching server fields", async () => {
+    readFileMock.mockResolvedValueOnce(
+      JSON.stringify({
+        mcpServers: {
+          mixed: {
+            command: "node",
+            url: "https://example.com/mcp",
+            args: ["server.js"],
+          },
+        },
+      })
+    );
+
+    const result = await loadMCPConfig();
+
+    expect(result.mcpServers.mixed).toEqual({
+      command: "node",
+      args: ["server.js"],
+    });
+    expect(isStdioConfig(result.mcpServers.mixed)).toBe(true);
   });
 
   it("accepts an empty mcpServers object", async () => {

--- a/packages/harness/src/mcp-config.test.ts
+++ b/packages/harness/src/mcp-config.test.ts
@@ -59,16 +59,20 @@ describe("loadMCPConfig", () => {
     const result = await loadMCPConfig();
     const config = result.mcpServers.remote;
 
-    expect(config).toEqual(validConfig.mcpServers.remote);
+    expect(config).toEqual({
+      ...validConfig.mcpServers.remote,
+      type: "http",
+    });
     expect(isRemoteConfig(config)).toBe(true);
     expect(isStdioConfig(config)).toBe(false);
   });
 
-  it("parses a valid SSE config with only a url", async () => {
+  it("parses a valid SSE config with explicit sse transport type", async () => {
     const validConfig = {
       mcpServers: {
         events: {
           url: "https://example.com/sse",
+          type: "sse",
         },
       },
     };
@@ -81,6 +85,25 @@ describe("loadMCPConfig", () => {
     expect(isRemoteConfig(result.mcpServers.events)).toBe(true);
   });
 
+  it("defaults remote transport type to http when not specified", async () => {
+    readFileMock.mockResolvedValueOnce(
+      JSON.stringify({
+        mcpServers: {
+          remote: {
+            url: "https://example.com/mcp",
+          },
+        },
+      })
+    );
+
+    const result = await loadMCPConfig();
+
+    expect(result.mcpServers.remote).toEqual({
+      url: "https://example.com/mcp",
+      type: "http",
+    });
+  });
+
   it("parses mixed server configs", async () => {
     const validConfig = {
       mcpServers: {
@@ -90,12 +113,14 @@ describe("loadMCPConfig", () => {
         },
         httpServer: {
           url: "https://example.com/http",
+          type: "http",
           headers: {
             "x-api-key": "secret",
           },
         },
         sseServer: {
           url: "https://example.com/sse",
+          type: "sse",
         },
       },
     };

--- a/packages/harness/src/mcp-config.test.ts
+++ b/packages/harness/src/mcp-config.test.ts
@@ -1,0 +1,196 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const INVALID_CONFIG_ERROR_PATTERN = /Invalid \.mcp\.json:/;
+const DEFAULT_CONFIG_PATH_PATTERN = /[\\/]\.mcp\.json$/;
+
+const { readFileMock } = vi.hoisted(() => {
+  const mock = vi.fn();
+  return { readFileMock: mock };
+});
+
+vi.mock("node:fs/promises", () => ({
+  readFile: readFileMock,
+}));
+
+import { isRemoteConfig, isStdioConfig, loadMCPConfig } from "./mcp-config";
+
+describe("loadMCPConfig", () => {
+  beforeEach(() => {
+    readFileMock.mockReset();
+  });
+
+  it("parses a valid stdio config", async () => {
+    const validConfig = {
+      mcpServers: {
+        filesystem: {
+          command: "node",
+          args: ["server.js", "--stdio"],
+          env: {
+            NODE_ENV: "test",
+          },
+        },
+      },
+    };
+
+    readFileMock.mockResolvedValueOnce(JSON.stringify(validConfig));
+
+    const result = await loadMCPConfig();
+    const config = result.mcpServers.filesystem;
+
+    expect(config).toEqual(validConfig.mcpServers.filesystem);
+    expect(isStdioConfig(config)).toBe(true);
+    expect(isRemoteConfig(config)).toBe(false);
+  });
+
+  it("parses a valid HTTP config with headers", async () => {
+    const validConfig = {
+      mcpServers: {
+        remote: {
+          url: "https://example.com/mcp",
+          headers: {
+            Authorization: "Bearer token",
+          },
+        },
+      },
+    };
+
+    readFileMock.mockResolvedValueOnce(JSON.stringify(validConfig));
+
+    const result = await loadMCPConfig();
+    const config = result.mcpServers.remote;
+
+    expect(config).toEqual(validConfig.mcpServers.remote);
+    expect(isRemoteConfig(config)).toBe(true);
+    expect(isStdioConfig(config)).toBe(false);
+  });
+
+  it("parses a valid SSE config with only a url", async () => {
+    const validConfig = {
+      mcpServers: {
+        events: {
+          url: "https://example.com/sse",
+        },
+      },
+    };
+
+    readFileMock.mockResolvedValueOnce(JSON.stringify(validConfig));
+
+    const result = await loadMCPConfig();
+
+    expect(result).toEqual(validConfig);
+    expect(isRemoteConfig(result.mcpServers.events)).toBe(true);
+  });
+
+  it("parses mixed server configs", async () => {
+    const validConfig = {
+      mcpServers: {
+        filesystem: {
+          command: "node",
+          args: ["server.js"],
+        },
+        httpServer: {
+          url: "https://example.com/http",
+          headers: {
+            "x-api-key": "secret",
+          },
+        },
+        sseServer: {
+          url: "https://example.com/sse",
+        },
+      },
+    };
+
+    readFileMock.mockResolvedValueOnce(JSON.stringify(validConfig));
+
+    const result = await loadMCPConfig();
+
+    expect(result).toEqual(validConfig);
+  });
+
+  it("returns empty config when file is missing", async () => {
+    readFileMock.mockRejectedValueOnce(
+      Object.assign(new Error("ENOENT: no such file"), { code: "ENOENT" })
+    );
+
+    const result = await loadMCPConfig({
+      configPath: "/nonexistent/.mcp.json",
+    });
+
+    expect(result).toEqual({ mcpServers: {} });
+  });
+
+  it("throws a descriptive error for malformed JSON", async () => {
+    readFileMock.mockResolvedValueOnce("{ invalid json");
+
+    await expect(loadMCPConfig()).rejects.toThrow(INVALID_CONFIG_ERROR_PATTERN);
+  });
+
+  it("throws a validation error when a server has neither command nor url", async () => {
+    const invalidConfig = {
+      mcpServers: {
+        broken: {
+          headers: {
+            Authorization: "Bearer token",
+          },
+        },
+      },
+    };
+
+    readFileMock.mockResolvedValueOnce(JSON.stringify(invalidConfig));
+
+    await expect(loadMCPConfig()).rejects.toThrow(INVALID_CONFIG_ERROR_PATTERN);
+  });
+
+  it("ignores unknown extra fields at the root and server level", async () => {
+    const configWithExtras = {
+      mcpServers: {
+        filesystem: {
+          command: "node",
+          args: ["server.js"],
+          extraField: "ignored",
+        },
+      },
+      version: 1,
+    };
+
+    readFileMock.mockResolvedValueOnce(JSON.stringify(configWithExtras));
+
+    const result = await loadMCPConfig();
+
+    expect(result).toMatchObject({
+      mcpServers: {
+        filesystem: {
+          command: "node",
+          args: ["server.js"],
+        },
+      },
+      version: 1,
+    });
+    expect(result.mcpServers.filesystem).not.toHaveProperty("extraField");
+  });
+
+  it("accepts an empty mcpServers object", async () => {
+    readFileMock.mockResolvedValueOnce(JSON.stringify({ mcpServers: {} }));
+
+    await expect(loadMCPConfig()).resolves.toEqual({ mcpServers: {} });
+  });
+
+  it("reads from a custom config path override", async () => {
+    readFileMock.mockResolvedValueOnce(JSON.stringify({ mcpServers: {} }));
+
+    await loadMCPConfig({ configPath: "/tmp/custom.mcp.json" });
+
+    expect(readFileMock).toHaveBeenCalledWith("/tmp/custom.mcp.json", "utf-8");
+  });
+
+  it("uses process.cwd()/.mcp.json by default", async () => {
+    readFileMock.mockResolvedValueOnce(JSON.stringify({ mcpServers: {} }));
+
+    await loadMCPConfig();
+
+    expect(readFileMock).toHaveBeenCalledWith(
+      expect.stringMatching(DEFAULT_CONFIG_PATH_PATTERN),
+      "utf-8"
+    );
+  });
+});

--- a/packages/harness/src/mcp-config.ts
+++ b/packages/harness/src/mcp-config.ts
@@ -22,6 +22,7 @@ const MCPStdioServerConfigSchema = z
 const MCPRemoteServerConfigSchema = z
   .object({
     url: z.string().url(),
+    type: z.enum(["http", "sse"]).optional().default("http"),
     headers: z.record(z.string(), z.string()).optional(),
   })
   .strip();

--- a/packages/harness/src/mcp-config.ts
+++ b/packages/harness/src/mcp-config.ts
@@ -13,7 +13,7 @@ const INVALID_MCP_CONFIG_PREFIX = "Invalid .mcp.json:";
 
 const MCPStdioServerConfigSchema = z
   .object({
-    command: z.string(),
+    command: z.string().min(1, "command must not be empty"),
     args: z.array(z.string()).optional(),
     env: z.record(z.string(), z.string()).optional(),
   })

--- a/packages/harness/src/mcp-config.ts
+++ b/packages/harness/src/mcp-config.ts
@@ -1,0 +1,97 @@
+import { readFile } from "node:fs/promises";
+import { join } from "node:path";
+import { z } from "zod";
+
+import type {
+  MCPConfigFile,
+  MCPRemoteServerConfig,
+  MCPServerConfig,
+  MCPStdioServerConfig,
+} from "./mcp-types.js";
+
+const INVALID_MCP_CONFIG_PREFIX = "Invalid .mcp.json:";
+
+const MCPStdioServerConfigSchema = z
+  .object({
+    command: z.string(),
+    args: z.array(z.string()).optional(),
+    env: z.record(z.string(), z.string()).optional(),
+  })
+  .strip();
+
+const MCPRemoteServerConfigSchema = z
+  .object({
+    url: z.string().url(),
+    headers: z.record(z.string(), z.string()).optional(),
+  })
+  .strip();
+
+const MCPServerConfigSchema = z.union([
+  MCPStdioServerConfigSchema,
+  MCPRemoteServerConfigSchema,
+]);
+
+const MCPConfigFileSchema = z
+  .object({
+    mcpServers: z.record(z.string(), MCPServerConfigSchema),
+  })
+  .passthrough();
+
+export async function loadMCPConfig(options?: {
+  configPath?: string;
+}): Promise<MCPConfigFile> {
+  const configPath = options?.configPath ?? join(process.cwd(), ".mcp.json");
+
+  try {
+    const content = await readFile(configPath, "utf-8");
+    const parsed = parseMCPConfigContent(content);
+    return MCPConfigFileSchema.parse(parsed) as MCPConfigFile;
+  } catch (error) {
+    if (isEnoentError(error)) {
+      return { mcpServers: {} };
+    }
+
+    if (error instanceof z.ZodError) {
+      throw new Error(
+        `${INVALID_MCP_CONFIG_PREFIX} ${JSON.stringify(error.format(), null, 2)}`
+      );
+    }
+
+    throw error;
+  }
+}
+
+export function isStdioConfig(
+  config: MCPServerConfig
+): config is MCPStdioServerConfig {
+  return "command" in config;
+}
+
+export function isRemoteConfig(
+  config: MCPServerConfig
+): config is MCPRemoteServerConfig {
+  return "url" in config;
+}
+
+function isEnoentError(error: unknown): error is NodeJS.ErrnoException {
+  return (
+    typeof error === "object" &&
+    error !== null &&
+    "code" in error &&
+    error.code === "ENOENT"
+  );
+}
+
+function parseMCPConfigContent(content: string): unknown {
+  try {
+    return JSON.parse(content);
+  } catch {
+    throw new z.ZodError([
+      {
+        code: "custom",
+        message: "Invalid JSON in .mcp.json",
+        path: [],
+      },
+    ]);
+  }
+}

--- a/packages/harness/src/mcp-init.test.ts
+++ b/packages/harness/src/mcp-init.test.ts
@@ -1,5 +1,5 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { ToolSet } from "ai";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const { managerCloseMock, managerInitMock, managerToolsByServerMock } =
   vi.hoisted(() => ({
@@ -29,8 +29,8 @@ vi.mock("./mcp-manager.js", () => ({
 import { loadMCPConfig } from "./mcp-config.js";
 import { clearMCPCache, resolveMCPOption } from "./mcp-init.js";
 import { MCPManager } from "./mcp-manager.js";
-import type { MCPServerConfig } from "./mcp-types.js";
 import { mergeMCPTools } from "./mcp-tool-merger.js";
+import type { MCPServerConfig } from "./mcp-types.js";
 
 const loadMCPConfigMock = vi.mocked(loadMCPConfig);
 const mergeMCPToolsMock = vi.mocked(mergeMCPTools);

--- a/packages/harness/src/mcp-init.test.ts
+++ b/packages/harness/src/mcp-init.test.ts
@@ -1,0 +1,196 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { ToolSet } from "ai";
+
+const { managerCloseMock, managerInitMock, managerToolsByServerMock } =
+  vi.hoisted(() => ({
+    managerCloseMock: vi.fn(),
+    managerInitMock: vi.fn(),
+    managerToolsByServerMock: vi.fn(),
+  }));
+
+vi.mock("./mcp-config.js", () => ({
+  loadMCPConfig: vi.fn(),
+  isRemoteConfig: vi.fn(),
+  isStdioConfig: vi.fn(),
+}));
+
+vi.mock("./mcp-tool-merger.js", () => ({
+  mergeMCPTools: vi.fn(),
+}));
+
+vi.mock("./mcp-manager.js", () => ({
+  MCPManager: class MockMCPManager {
+    close = managerCloseMock;
+    init = managerInitMock;
+    toolsByServer = managerToolsByServerMock;
+  },
+}));
+
+import { loadMCPConfig } from "./mcp-config.js";
+import { clearMCPCache, resolveMCPOption } from "./mcp-init.js";
+import { MCPManager } from "./mcp-manager.js";
+import type { MCPServerConfig } from "./mcp-types.js";
+import { mergeMCPTools } from "./mcp-tool-merger.js";
+
+const loadMCPConfigMock = vi.mocked(loadMCPConfig);
+const mergeMCPToolsMock = vi.mocked(mergeMCPTools);
+
+describe("resolveMCPOption", () => {
+  const localTools = {
+    local_tool: { description: "local" },
+  } as unknown as ToolSet;
+
+  const mergedTools = {
+    merged_tool: { description: "merged" },
+  } as unknown as ToolSet;
+
+  beforeEach(() => {
+    clearMCPCache();
+    vi.clearAllMocks();
+
+    loadMCPConfigMock.mockResolvedValue({
+      mcpServers: {
+        remote: { url: "http://example.com" },
+      },
+    });
+    managerInitMock.mockResolvedValue(undefined);
+    managerToolsByServerMock.mockReturnValue({
+      remote: { mcp_tool: { description: "mcp" } },
+    });
+    managerCloseMock.mockResolvedValue(undefined);
+    mergeMCPToolsMock.mockReturnValue({ conflicts: [], tools: mergedTools });
+  });
+
+  it("creates manager for mcp=true, initializes it, and merges tools", async () => {
+    const result = await resolveMCPOption(true, localTools);
+
+    expect(loadMCPConfigMock).toHaveBeenCalledWith();
+    expect(managerInitMock).toHaveBeenCalledTimes(1);
+    expect(mergeMCPToolsMock).toHaveBeenCalledWith({
+      localTools,
+      mcpTools: {
+        remote: { mcp_tool: { description: "mcp" } },
+      },
+    });
+    expect(result.tools).toBe(mergedTools);
+  });
+
+  it("returns local tools when mcp=true and config file is missing", async () => {
+    loadMCPConfigMock.mockResolvedValueOnce({ mcpServers: {} });
+
+    const result = await resolveMCPOption(true, localTools);
+
+    expect(managerInitMock).not.toHaveBeenCalled();
+    expect(mergeMCPToolsMock).not.toHaveBeenCalled();
+    expect(result.tools).toBe(localTools);
+    await result.close();
+  });
+
+  it("uses inline servers when mcp is an MCPServerConfig array", async () => {
+    const servers: MCPServerConfig[] = [{ url: "http://test.com" }];
+
+    await resolveMCPOption(servers, localTools);
+
+    expect(managerInitMock).toHaveBeenCalledTimes(1);
+    expect(mergeMCPToolsMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("combines config and inline servers when both are provided", async () => {
+    await resolveMCPOption(
+      {
+        config: true,
+        servers: [{ url: "http://inline.com" }],
+      },
+      localTools
+    );
+
+    expect(loadMCPConfigMock).toHaveBeenCalledWith(undefined);
+    expect(managerInitMock).toHaveBeenCalledTimes(1);
+    expect(mergeMCPToolsMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("uses provided MCPManager instance and returns no-op close", async () => {
+    const manager = new MCPManager();
+    vi.mocked(manager.toolsByServer).mockReturnValue({
+      provided: {
+        provided_tool: {
+          description: "provided",
+        } as unknown as ToolSet[string],
+      },
+    });
+
+    const result = await resolveMCPOption(manager, localTools);
+
+    expect(manager.toolsByServer).toHaveBeenCalledTimes(1);
+    expect(mergeMCPToolsMock).toHaveBeenCalledWith({
+      localTools,
+      mcpTools: {
+        provided: { provided_tool: { description: "provided" } },
+      },
+    });
+    await result.close();
+    expect(managerCloseMock).not.toHaveBeenCalled();
+  });
+
+  it("reuses manager for repeated mcp=true config and initializes once", async () => {
+    await resolveMCPOption(true, localTools);
+    await resolveMCPOption(true, localTools);
+
+    expect(managerInitMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps manager alive until all shared users close", async () => {
+    const first = await resolveMCPOption(true, localTools);
+    const second = await resolveMCPOption(true, localTools);
+
+    await first.close();
+
+    expect(managerCloseMock).not.toHaveBeenCalled();
+
+    await second.close();
+
+    expect(managerCloseMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("closes manager when refcount reaches zero", async () => {
+    const first = await resolveMCPOption(true, localTools);
+    const second = await resolveMCPOption(true, localTools);
+
+    await second.close();
+    expect(managerCloseMock).not.toHaveBeenCalled();
+
+    await first.close();
+    expect(managerCloseMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("makes cached close idempotent", async () => {
+    const result = await resolveMCPOption(true, localTools);
+
+    await result.close();
+    await result.close();
+
+    expect(managerCloseMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("builds stable cache key for inline servers regardless of property order", async () => {
+    const firstServers: MCPServerConfig[] = [
+      {
+        headers: { authorization: "Bearer token" },
+        type: "http",
+        url: "http://test.com",
+      },
+    ];
+    const secondServers: MCPServerConfig[] = [
+      {
+        url: "http://test.com",
+        type: "http",
+        headers: { authorization: "Bearer token" },
+      },
+    ];
+
+    await resolveMCPOption(firstServers, localTools);
+    await resolveMCPOption(secondServers, localTools);
+
+    expect(managerInitMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/harness/src/mcp-init.ts
+++ b/packages/harness/src/mcp-init.ts
@@ -80,6 +80,7 @@ function getOrCreateEntry(
   options: {
     configPath?: string;
     onError?: (server: string, error: unknown) => void;
+    servers?: Record<string, MCPServerConfig>;
     toolsTimeout?: number;
   }
 ): CacheEntry {
@@ -92,6 +93,7 @@ function getOrCreateEntry(
   const manager = new MCPManager({
     configPath: options.configPath,
     onError: options.onError,
+    servers: options.servers,
     toolsTimeout: options.toolsTimeout,
   });
   const entry: CacheEntry = {
@@ -108,6 +110,7 @@ async function resolveConfig(mcp: Exclude<MCPOption, MCPManager>): Promise<{
   options: {
     configPath?: string;
     onError?: (server: string, error: unknown) => void;
+    servers?: Record<string, MCPServerConfig>;
     toolsTimeout?: number;
   };
   servers: Record<string, MCPServerConfig>;
@@ -122,10 +125,11 @@ async function resolveConfig(mcp: Exclude<MCPOption, MCPManager>): Promise<{
   }
 
   if (Array.isArray(mcp)) {
+    const named = arrayToNamedServers(mcp);
     return {
       cacheKey: `inline:${stableStringify(sortServers(mcp))}`,
-      options: {},
-      servers: arrayToNamedServers(mcp),
+      options: { servers: named },
+      servers: named,
     };
   }
 
@@ -134,17 +138,17 @@ async function resolveConfig(mcp: Exclude<MCPOption, MCPManager>): Promise<{
     ? (await loadMCPConfig(configPath ? { configPath } : undefined)).mcpServers
     : {};
   const inlineServers = mcp.servers ?? [];
+  const namedInline = arrayToNamedServers(inlineServers, "inline");
+  const allServers = { ...fileServers, ...namedInline };
   return {
     cacheKey: `combined:${configPath ?? (mcp.config ? ".mcp.json" : "")}+${stableStringify(sortServers(inlineServers))}`,
     options: {
-      configPath,
+      configPath: mcp.config ? configPath : undefined,
       onError: mcp.onError,
+      servers: Object.keys(namedInline).length > 0 ? namedInline : undefined,
       toolsTimeout: mcp.toolsTimeout,
     },
-    servers: {
-      ...fileServers,
-      ...arrayToNamedServers(inlineServers, "inline"),
-    },
+    servers: allServers,
   };
 }
 

--- a/packages/harness/src/mcp-init.ts
+++ b/packages/harness/src/mcp-init.ts
@@ -1,3 +1,5 @@
+import { join, resolve } from "node:path";
+
 import type { ToolSet } from "ai";
 
 import { loadMCPConfig } from "./mcp-config.js";
@@ -141,6 +143,9 @@ async function resolveConfig(mcp: Exclude<MCPOption, MCPManager>): Promise<{
   }
 
   const configPath = typeof mcp.config === "string" ? mcp.config : undefined;
+  const resolvedConfigPath = mcp.config
+    ? resolve(configPath ?? join(process.cwd(), ".mcp.json"))
+    : undefined;
   const fileServers = mcp.config
     ? (await loadMCPConfig(configPath ? { configPath } : undefined)).mcpServers
     : {};
@@ -150,7 +155,7 @@ async function resolveConfig(mcp: Exclude<MCPOption, MCPManager>): Promise<{
   const timeoutSuffix =
     mcp.toolsTimeout !== undefined ? `+timeout:${mcp.toolsTimeout}` : "";
   return {
-    cacheKey: `combined:${configPath ?? (mcp.config ? ".mcp.json" : "")}+${stableStringify(inlineServers)}${timeoutSuffix}`,
+    cacheKey: `combined:${resolvedConfigPath ?? ""}+${stableStringify(inlineServers)}${timeoutSuffix}`,
     options: {
       configPath: mcp.config ? configPath : undefined,
       loadFileConfig: mcp.config ? true : undefined,

--- a/packages/harness/src/mcp-init.ts
+++ b/packages/harness/src/mcp-init.ts
@@ -79,6 +79,7 @@ function getOrCreateEntry(
   cacheKey: string,
   options: {
     configPath?: string;
+    loadFileConfig?: boolean;
     onError?: (server: string, error: unknown) => void;
     servers?: Record<string, MCPServerConfig>;
     toolsTimeout?: number;
@@ -92,6 +93,7 @@ function getOrCreateEntry(
 
   const manager = new MCPManager({
     configPath: options.configPath,
+    loadFileConfig: options.loadFileConfig,
     onError: options.onError,
     servers: options.servers,
     toolsTimeout: options.toolsTimeout,
@@ -113,6 +115,7 @@ async function resolveConfig(mcp: Exclude<MCPOption, MCPManager>): Promise<{
   cacheKey: string;
   options: {
     configPath?: string;
+    loadFileConfig?: boolean;
     onError?: (server: string, error: unknown) => void;
     servers?: Record<string, MCPServerConfig>;
     toolsTimeout?: number;
@@ -146,12 +149,11 @@ async function resolveConfig(mcp: Exclude<MCPOption, MCPManager>): Promise<{
   const allServers = { ...fileServers, ...namedInline };
   const timeoutSuffix =
     mcp.toolsTimeout !== undefined ? `+timeout:${mcp.toolsTimeout}` : "";
-  const onErrorSuffix =
-    mcp.onError !== undefined ? `+onError:${uniqueId()}` : "";
   return {
-    cacheKey: `combined:${configPath ?? (mcp.config ? ".mcp.json" : "")}+${stableStringify(sortServers(inlineServers))}${timeoutSuffix}${onErrorSuffix}`,
+    cacheKey: `combined:${configPath ?? (mcp.config ? ".mcp.json" : "")}+${stableStringify(sortServers(inlineServers))}${timeoutSuffix}`,
     options: {
       configPath: mcp.config ? configPath : undefined,
+      loadFileConfig: mcp.config ? true : undefined,
       onError: mcp.onError,
       servers: Object.keys(namedInline).length > 0 ? namedInline : undefined,
       toolsTimeout: mcp.toolsTimeout,
@@ -173,11 +175,6 @@ function sortServers(servers: MCPServerConfig[]): MCPServerConfig[] {
   return [...servers].sort((left, right) =>
     stableStringify(left).localeCompare(stableStringify(right))
   );
-}
-
-let _uniqueCounter = 0;
-function uniqueId(): number {
-  return ++_uniqueCounter;
 }
 
 function stableStringify(value: unknown): string {

--- a/packages/harness/src/mcp-init.ts
+++ b/packages/harness/src/mcp-init.ts
@@ -1,0 +1,182 @@
+import type { ToolSet } from "ai";
+
+import { loadMCPConfig } from "./mcp-config.js";
+import { MCPManager } from "./mcp-manager.js";
+import { mergeMCPTools } from "./mcp-tool-merger.js";
+import type { MCPServerConfig } from "./mcp-types.js";
+import type { MCPOption } from "./types.js";
+
+interface CacheEntry {
+  initPromise: Promise<void>;
+  manager: MCPManager;
+  refCount: number;
+}
+
+const cache = new Map<string, CacheEntry>();
+
+export async function resolveMCPOption(
+  mcp: MCPOption,
+  localTools: ToolSet
+): Promise<{ tools: ToolSet; close: () => Promise<void> }> {
+  if (mcp instanceof MCPManager) {
+    const { tools } = mergeMCPTools({
+      localTools,
+      mcpTools: mcp.toolsByServer(),
+    });
+
+    return {
+      tools,
+      close: async () => undefined,
+    };
+  }
+
+  const resolved = await resolveConfig(mcp);
+  if (!resolved || Object.keys(resolved.servers).length === 0) {
+    return {
+      tools: localTools,
+      close: async () => undefined,
+    };
+  }
+
+  const entry = getOrCreateEntry(resolved.cacheKey, resolved.options);
+  await entry.initPromise;
+
+  const { tools } = mergeMCPTools({
+    localTools,
+    mcpTools: entry.manager.toolsByServer(),
+  });
+
+  let closed = false;
+  return {
+    tools,
+    close: async () => {
+      if (closed) {
+        return;
+      }
+      closed = true;
+
+      const current = cache.get(resolved.cacheKey);
+      if (!current) {
+        return;
+      }
+
+      current.refCount -= 1;
+      if (current.refCount > 0) {
+        return;
+      }
+
+      cache.delete(resolved.cacheKey);
+      await current.manager.close();
+    },
+  };
+}
+
+export function clearMCPCache(): void {
+  cache.clear();
+}
+
+function getOrCreateEntry(
+  cacheKey: string,
+  options: {
+    configPath?: string;
+    onError?: (server: string, error: unknown) => void;
+    toolsTimeout?: number;
+  }
+): CacheEntry {
+  const existing = cache.get(cacheKey);
+  if (existing) {
+    existing.refCount += 1;
+    return existing;
+  }
+
+  const manager = new MCPManager({
+    configPath: options.configPath,
+    onError: options.onError,
+    toolsTimeout: options.toolsTimeout,
+  });
+  const entry: CacheEntry = {
+    manager,
+    refCount: 1,
+    initPromise: manager.init(),
+  };
+  cache.set(cacheKey, entry);
+  return entry;
+}
+
+async function resolveConfig(mcp: Exclude<MCPOption, MCPManager>): Promise<{
+  cacheKey: string;
+  options: {
+    configPath?: string;
+    onError?: (server: string, error: unknown) => void;
+    toolsTimeout?: number;
+  };
+  servers: Record<string, MCPServerConfig>;
+} | null> {
+  if (mcp === true) {
+    const loaded = await loadMCPConfig();
+    return {
+      cacheKey: "file:.mcp.json",
+      options: {},
+      servers: loaded.mcpServers,
+    };
+  }
+
+  if (Array.isArray(mcp)) {
+    return {
+      cacheKey: `inline:${stableStringify(sortServers(mcp))}`,
+      options: {},
+      servers: arrayToNamedServers(mcp),
+    };
+  }
+
+  const configPath = typeof mcp.config === "string" ? mcp.config : undefined;
+  const fileServers = mcp.config
+    ? (await loadMCPConfig(configPath ? { configPath } : undefined)).mcpServers
+    : {};
+  const inlineServers = mcp.servers ?? [];
+  return {
+    cacheKey: `combined:${configPath ?? (mcp.config ? ".mcp.json" : "")}+${stableStringify(sortServers(inlineServers))}`,
+    options: {
+      configPath,
+      onError: mcp.onError,
+      toolsTimeout: mcp.toolsTimeout,
+    },
+    servers: {
+      ...fileServers,
+      ...arrayToNamedServers(inlineServers, "inline"),
+    },
+  };
+}
+
+function arrayToNamedServers(
+  servers: MCPServerConfig[],
+  prefix = "server"
+): Record<string, MCPServerConfig> {
+  return Object.fromEntries(
+    servers.map((server, index) => [`${prefix}-${index + 1}`, server])
+  );
+}
+
+function sortServers(servers: MCPServerConfig[]): MCPServerConfig[] {
+  return [...servers].sort((left, right) =>
+    stableStringify(left).localeCompare(stableStringify(right))
+  );
+}
+
+function stableStringify(value: unknown): string {
+  if (Array.isArray(value)) {
+    return `[${value.map((item) => stableStringify(item)).join(",")}]`;
+  }
+
+  if (value && typeof value === "object") {
+    return `{${Object.entries(value)
+      .sort(([left], [right]) => left.localeCompare(right))
+      .map(
+        ([key, entryValue]) =>
+          `${JSON.stringify(key)}:${stableStringify(entryValue)}`
+      )
+      .join(",")}}`;
+  }
+
+  return JSON.stringify(value);
+}

--- a/packages/harness/src/mcp-init.ts
+++ b/packages/harness/src/mcp-init.ts
@@ -125,7 +125,7 @@ async function resolveConfig(mcp: Exclude<MCPOption, MCPManager>): Promise<{
   if (mcp === true) {
     const loaded = await loadMCPConfig();
     return {
-      cacheKey: "file:.mcp.json",
+      cacheKey: `file:${process.cwd()}/.mcp.json`,
       options: {},
       servers: loaded.mcpServers,
     };
@@ -134,7 +134,7 @@ async function resolveConfig(mcp: Exclude<MCPOption, MCPManager>): Promise<{
   if (Array.isArray(mcp)) {
     const named = arrayToNamedServers(mcp);
     return {
-      cacheKey: `inline:${stableStringify(sortServers(mcp))}`,
+      cacheKey: `inline:${stableStringify(mcp)}`,
       options: { servers: named },
       servers: named,
     };
@@ -150,7 +150,7 @@ async function resolveConfig(mcp: Exclude<MCPOption, MCPManager>): Promise<{
   const timeoutSuffix =
     mcp.toolsTimeout !== undefined ? `+timeout:${mcp.toolsTimeout}` : "";
   return {
-    cacheKey: `combined:${configPath ?? (mcp.config ? ".mcp.json" : "")}+${stableStringify(sortServers(inlineServers))}${timeoutSuffix}`,
+    cacheKey: `combined:${configPath ?? (mcp.config ? ".mcp.json" : "")}+${stableStringify(inlineServers)}${timeoutSuffix}`,
     options: {
       configPath: mcp.config ? configPath : undefined,
       loadFileConfig: mcp.config ? true : undefined,
@@ -168,12 +168,6 @@ function arrayToNamedServers(
 ): Record<string, MCPServerConfig> {
   return Object.fromEntries(
     servers.map((server, index) => [`${prefix}-${index + 1}`, server])
-  );
-}
-
-function sortServers(servers: MCPServerConfig[]): MCPServerConfig[] {
-  return [...servers].sort((left, right) =>
-    stableStringify(left).localeCompare(stableStringify(right))
   );
 }
 

--- a/packages/harness/src/mcp-init.ts
+++ b/packages/harness/src/mcp-init.ts
@@ -96,10 +96,14 @@ function getOrCreateEntry(
     servers: options.servers,
     toolsTimeout: options.toolsTimeout,
   });
+  const initPromise = manager.init().catch((error) => {
+    cache.delete(cacheKey);
+    throw error;
+  });
   const entry: CacheEntry = {
     manager,
     refCount: 1,
-    initPromise: manager.init(),
+    initPromise,
   };
   cache.set(cacheKey, entry);
   return entry;
@@ -142,8 +146,10 @@ async function resolveConfig(mcp: Exclude<MCPOption, MCPManager>): Promise<{
   const allServers = { ...fileServers, ...namedInline };
   const timeoutSuffix =
     mcp.toolsTimeout !== undefined ? `+timeout:${mcp.toolsTimeout}` : "";
+  const onErrorSuffix =
+    mcp.onError !== undefined ? `+onError:${uniqueId()}` : "";
   return {
-    cacheKey: `combined:${configPath ?? (mcp.config ? ".mcp.json" : "")}+${stableStringify(sortServers(inlineServers))}${timeoutSuffix}`,
+    cacheKey: `combined:${configPath ?? (mcp.config ? ".mcp.json" : "")}+${stableStringify(sortServers(inlineServers))}${timeoutSuffix}${onErrorSuffix}`,
     options: {
       configPath: mcp.config ? configPath : undefined,
       onError: mcp.onError,
@@ -167,6 +173,11 @@ function sortServers(servers: MCPServerConfig[]): MCPServerConfig[] {
   return [...servers].sort((left, right) =>
     stableStringify(left).localeCompare(stableStringify(right))
   );
+}
+
+let _uniqueCounter = 0;
+function uniqueId(): number {
+  return ++_uniqueCounter;
 }
 
 function stableStringify(value: unknown): string {

--- a/packages/harness/src/mcp-init.ts
+++ b/packages/harness/src/mcp-init.ts
@@ -140,8 +140,10 @@ async function resolveConfig(mcp: Exclude<MCPOption, MCPManager>): Promise<{
   const inlineServers = mcp.servers ?? [];
   const namedInline = arrayToNamedServers(inlineServers, "inline");
   const allServers = { ...fileServers, ...namedInline };
+  const timeoutSuffix =
+    mcp.toolsTimeout !== undefined ? `+timeout:${mcp.toolsTimeout}` : "";
   return {
-    cacheKey: `combined:${configPath ?? (mcp.config ? ".mcp.json" : "")}+${stableStringify(sortServers(inlineServers))}`,
+    cacheKey: `combined:${configPath ?? (mcp.config ? ".mcp.json" : "")}+${stableStringify(sortServers(inlineServers))}${timeoutSuffix}`,
     options: {
       configPath: mcp.config ? configPath : undefined,
       onError: mcp.onError,

--- a/packages/harness/src/mcp-manager.test.ts
+++ b/packages/harness/src/mcp-manager.test.ts
@@ -1,0 +1,388 @@
+import type { ToolSet } from "ai";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const NOT_INITIALIZED_ERROR_PATTERN = /not initialized/i;
+
+const {
+  createMCPClientMock,
+  stdioTransportMock,
+  loadMCPConfigMock,
+  isStdioConfigMock,
+  mergeMCPToolsMock,
+  timeoutSpy,
+  clearTimeoutSpy,
+} = vi.hoisted(() => ({
+  createMCPClientMock: vi.fn(),
+  stdioTransportMock: vi.fn().mockImplementation((options) => options),
+  loadMCPConfigMock: vi.fn(),
+  isStdioConfigMock: vi.fn(),
+  mergeMCPToolsMock: vi.fn(),
+  timeoutSpy: vi.fn((callback: () => void) => {
+    const handle = { cancelled: false };
+    Promise.resolve().then(() => {
+      if (!handle.cancelled) {
+        callback();
+      }
+    });
+    return handle;
+  }),
+  clearTimeoutSpy: vi.fn((handle: { cancelled?: boolean }) => {
+    if (handle) {
+      handle.cancelled = true;
+    }
+  }),
+}));
+
+vi.mock("@ai-sdk/mcp", () => ({
+  createMCPClient: createMCPClientMock,
+}));
+
+vi.mock("@ai-sdk/mcp/mcp-stdio", () => ({
+  Experimental_StdioMCPTransport: stdioTransportMock,
+}));
+
+vi.mock("./mcp-config.js", () => ({
+  loadMCPConfig: loadMCPConfigMock,
+  isStdioConfig: isStdioConfigMock,
+}));
+
+vi.mock("./mcp-tool-merger.js", () => ({
+  mergeMCPTools: mergeMCPToolsMock,
+}));
+
+import { MCPManager } from "./mcp-manager";
+
+function createToolSet(...names: string[]): ToolSet {
+  return Object.fromEntries(
+    names.map((name) => [
+      name,
+      {
+        description: `${name} description`,
+        parameters: {},
+      } as unknown as ToolSet[string],
+    ])
+  );
+}
+
+function createMockClient(toolsResult: Promise<ToolSet> | ToolSet = {}): {
+  tools: ReturnType<typeof vi.fn>;
+  close: ReturnType<typeof vi.fn>;
+} {
+  return {
+    tools:
+      toolsResult instanceof Promise
+        ? vi.fn().mockReturnValue(toolsResult)
+        : vi.fn().mockResolvedValue(toolsResult),
+    close: vi.fn().mockResolvedValue(undefined),
+  };
+}
+
+describe("MCPManager", () => {
+  beforeEach(() => {
+    createMCPClientMock.mockReset();
+    stdioTransportMock.mockReset();
+    loadMCPConfigMock.mockReset();
+    isStdioConfigMock.mockReset();
+    mergeMCPToolsMock.mockReset();
+    timeoutSpy.mockClear();
+    clearTimeoutSpy.mockClear();
+
+    vi.stubGlobal("setTimeout", timeoutSpy as unknown as typeof setTimeout);
+    vi.stubGlobal(
+      "clearTimeout",
+      clearTimeoutSpy as unknown as typeof clearTimeout
+    );
+
+    loadMCPConfigMock.mockResolvedValue({ mcpServers: {} });
+    isStdioConfigMock.mockImplementation(
+      (config: { command?: string }) => "command" in config
+    );
+    mergeMCPToolsMock.mockImplementation(({ localTools, mcpTools }) => ({
+      tools: {
+        ...localTools,
+        ...Object.assign({}, ...Object.values(mcpTools)),
+      },
+      conflicts: [],
+    }));
+  });
+
+  it("init() with valid config connects all servers, and tools() returns merged ToolSet", async () => {
+    const alphaTools = createToolSet("alpha_tool");
+    const betaTools = createToolSet("beta_tool");
+    const alphaClient = createMockClient(alphaTools);
+    const betaClient = createMockClient(betaTools);
+
+    loadMCPConfigMock.mockResolvedValue({
+      mcpServers: {
+        alpha: { url: "https://alpha.example.com/mcp" },
+        beta: { command: "beta-server", args: ["--stdio"] },
+      },
+    });
+    createMCPClientMock
+      .mockResolvedValueOnce(alphaClient)
+      .mockResolvedValueOnce(betaClient);
+    mergeMCPToolsMock.mockReturnValue({
+      tools: { ...alphaTools, ...betaTools },
+      conflicts: [],
+    });
+
+    const manager = new MCPManager();
+    await manager.init();
+
+    expect(createMCPClientMock).toHaveBeenCalledTimes(2);
+    expect(stdioTransportMock).toHaveBeenCalledTimes(1);
+    expect(manager.tools()).toEqual({ ...alphaTools, ...betaTools });
+    expect(manager.status()).toEqual([
+      { name: "alpha", status: "connected", toolCount: 1 },
+      { name: "beta", status: "connected", toolCount: 1 },
+    ]);
+  });
+
+  it("init() with one failing server warns via onError, connects others, and returns partial ToolSet", async () => {
+    const onError = vi.fn();
+    const alphaTools = createToolSet("alpha_tool");
+    const alphaClient = createMockClient(alphaTools);
+    const failure = new Error("connect failed");
+
+    loadMCPConfigMock.mockResolvedValue({
+      mcpServers: {
+        alpha: { url: "https://alpha.example.com/mcp" },
+        beta: { url: "https://beta.example.com/mcp" },
+      },
+    });
+    createMCPClientMock
+      .mockResolvedValueOnce(alphaClient)
+      .mockRejectedValueOnce(failure);
+    mergeMCPToolsMock.mockReturnValue({ tools: alphaTools, conflicts: [] });
+
+    const manager = new MCPManager({ onError });
+    await manager.init();
+
+    expect(onError).toHaveBeenCalledWith("beta", failure);
+    expect(manager.tools()).toEqual(alphaTools);
+    expect(manager.status()).toEqual([
+      { name: "alpha", status: "connected", toolCount: 1 },
+      {
+        name: "beta",
+        status: "failed",
+        toolCount: 0,
+        error: failure.toString(),
+      },
+    ]);
+  });
+
+  it("init() with all servers failing leaves tools() empty without throwing", async () => {
+    const failureA = new Error("alpha down");
+    const failureB = new Error("beta down");
+
+    loadMCPConfigMock.mockResolvedValue({
+      mcpServers: {
+        alpha: { url: "https://alpha.example.com/mcp" },
+        beta: { command: "beta-server" },
+      },
+    });
+    createMCPClientMock
+      .mockRejectedValueOnce(failureA)
+      .mockRejectedValueOnce(failureB);
+    mergeMCPToolsMock.mockReturnValue({ tools: {}, conflicts: [] });
+
+    const manager = new MCPManager();
+    await manager.init();
+
+    expect(manager.tools()).toEqual({});
+    expect(manager.status()).toEqual([
+      {
+        name: "alpha",
+        status: "failed",
+        toolCount: 0,
+        error: failureA.toString(),
+      },
+      {
+        name: "beta",
+        status: "failed",
+        toolCount: 0,
+        error: failureB.toString(),
+      },
+    ]);
+  });
+
+  it("init() called twice returns immediately without double connect", async () => {
+    const client = createMockClient(createToolSet("alpha_tool"));
+
+    loadMCPConfigMock.mockResolvedValue({
+      mcpServers: {
+        alpha: { url: "https://alpha.example.com/mcp" },
+      },
+    });
+    createMCPClientMock.mockResolvedValue(client);
+    mergeMCPToolsMock.mockReturnValue({
+      tools: createToolSet("alpha_tool"),
+      conflicts: [],
+    });
+
+    const manager = new MCPManager();
+    await manager.init();
+    await manager.init();
+
+    expect(createMCPClientMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("init() with no .mcp.json returns empty tools without error", async () => {
+    loadMCPConfigMock.mockResolvedValue({ mcpServers: {} });
+    mergeMCPToolsMock.mockReturnValue({ tools: {}, conflicts: [] });
+
+    const manager = new MCPManager();
+    await manager.init();
+
+    expect(manager.tools()).toEqual({});
+    expect(manager.status()).toEqual([]);
+  });
+
+  it("close() closes all clients", async () => {
+    const alphaClient = createMockClient(createToolSet("alpha_tool"));
+    const betaClient = createMockClient(createToolSet("beta_tool"));
+
+    loadMCPConfigMock.mockResolvedValue({
+      mcpServers: {
+        alpha: { url: "https://alpha.example.com/mcp" },
+        beta: { command: "beta-server" },
+      },
+    });
+    createMCPClientMock
+      .mockResolvedValueOnce(alphaClient)
+      .mockResolvedValueOnce(betaClient);
+    mergeMCPToolsMock.mockReturnValue({
+      tools: { ...createToolSet("alpha_tool"), ...createToolSet("beta_tool") },
+      conflicts: [],
+    });
+
+    const manager = new MCPManager();
+    await manager.init();
+    await manager.close();
+
+    expect(alphaClient.close).toHaveBeenCalledTimes(1);
+    expect(betaClient.close).toHaveBeenCalledTimes(1);
+    expect(manager.status()).toEqual([
+      { name: "alpha", status: "closed", toolCount: 1 },
+      { name: "beta", status: "closed", toolCount: 1 },
+    ]);
+  });
+
+  it("close() called twice is idempotent", async () => {
+    const client = createMockClient(createToolSet("alpha_tool"));
+
+    loadMCPConfigMock.mockResolvedValue({
+      mcpServers: {
+        alpha: { url: "https://alpha.example.com/mcp" },
+      },
+    });
+    createMCPClientMock.mockResolvedValue(client);
+    mergeMCPToolsMock.mockReturnValue({
+      tools: createToolSet("alpha_tool"),
+      conflicts: [],
+    });
+
+    const manager = new MCPManager();
+    await manager.init();
+    await manager.close();
+    await manager.close();
+
+    expect(client.close).toHaveBeenCalledTimes(1);
+  });
+
+  it("close() before init() does not throw", async () => {
+    const manager = new MCPManager();
+
+    await expect(manager.close()).resolves.toBeUndefined();
+  });
+
+  it("status() returns array of MCPServerStatus per server", async () => {
+    const alphaClient = createMockClient(
+      createToolSet("alpha_tool", "alpha_tool_two")
+    );
+    const betaClient = createMockClient(createToolSet("beta_tool"));
+
+    loadMCPConfigMock.mockResolvedValue({
+      mcpServers: {
+        alpha: { url: "https://alpha.example.com/mcp" },
+        beta: { url: "https://beta.example.com/mcp" },
+      },
+    });
+    createMCPClientMock
+      .mockResolvedValueOnce(alphaClient)
+      .mockResolvedValueOnce(betaClient);
+    mergeMCPToolsMock.mockReturnValue({ tools: {}, conflicts: [] });
+
+    const manager = new MCPManager();
+    await manager.init();
+
+    expect(manager.status()).toEqual([
+      { name: "alpha", status: "connected", toolCount: 2 },
+      { name: "beta", status: "connected", toolCount: 1 },
+    ]);
+  });
+
+  it("tools() before init() throws error containing not initialized", () => {
+    const manager = new MCPManager();
+
+    expect(() => manager.tools()).toThrow(NOT_INITIALIZED_ERROR_PATTERN);
+  });
+
+  it("transport timeout aborts tool loading after toolsTimeout and skips server", async () => {
+    const onError = vi.fn();
+    const neverResolvingTools = new Promise<ToolSet>(() => undefined);
+    const client = createMockClient(neverResolvingTools);
+
+    loadMCPConfigMock.mockResolvedValue({
+      mcpServers: {
+        alpha: { url: "https://alpha.example.com/mcp" },
+      },
+    });
+    createMCPClientMock.mockResolvedValue(client);
+    mergeMCPToolsMock.mockReturnValue({ tools: {}, conflicts: [] });
+
+    const manager = new MCPManager({ onError, toolsTimeout: 5 });
+    await manager.init();
+
+    expect(timeoutSpy).toHaveBeenCalledWith(expect.any(Function), 5);
+    expect(onError).toHaveBeenCalledTimes(1);
+    expect(manager.status()).toEqual([
+      {
+        name: "alpha",
+        status: "failed",
+        toolCount: 0,
+        error: expect.stringContaining("timed out"),
+      },
+    ]);
+  });
+
+  it("onError callback is invoked when tools() fetch fails", async () => {
+    const onError = vi.fn();
+    const failure = new Error("tools failed");
+    const client = {
+      tools: vi.fn().mockRejectedValue(failure),
+      close: vi.fn().mockResolvedValue(undefined),
+    };
+
+    loadMCPConfigMock.mockResolvedValue({
+      mcpServers: {
+        alpha: { url: "https://alpha.example.com/mcp" },
+      },
+    });
+    createMCPClientMock.mockResolvedValue(client);
+    mergeMCPToolsMock.mockReturnValue({ tools: {}, conflicts: [] });
+
+    const manager = new MCPManager({ onError });
+    await manager.init();
+
+    expect(onError).toHaveBeenCalledWith("alpha", failure);
+    expect(manager.status()).toEqual([
+      {
+        name: "alpha",
+        status: "failed",
+        toolCount: 0,
+        error: failure.toString(),
+      },
+    ]);
+  });
+});

--- a/packages/harness/src/mcp-manager.test.ts
+++ b/packages/harness/src/mcp-manager.test.ts
@@ -1,7 +1,8 @@
 import type { ToolSet } from "ai";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const NOT_INITIALIZED_ERROR_PATTERN = /not initialized/i;
+const CLOSED_ERROR_PATTERN = /closed/i;
 
 const {
   createMCPClientMock,
@@ -106,6 +107,10 @@ describe("MCPManager", () => {
     }));
   });
 
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
   it("init() with valid config connects all servers, and tools() returns merged ToolSet", async () => {
     const alphaTools = createToolSet("alpha_tool");
     const betaTools = createToolSet("beta_tool");
@@ -161,13 +166,13 @@ describe("MCPManager", () => {
     expect(onError).toHaveBeenCalledWith("beta", failure);
     expect(manager.tools()).toEqual(alphaTools);
     expect(manager.status()).toEqual([
-      { name: "alpha", status: "connected", toolCount: 1 },
       {
         name: "beta",
         status: "failed",
         toolCount: 0,
         error: failure.toString(),
       },
+      { name: "alpha", status: "connected", toolCount: 1 },
     ]);
   });
 
@@ -225,6 +230,44 @@ describe("MCPManager", () => {
     await manager.init();
 
     expect(createMCPClientMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("init() shares an in-flight initialization promise across concurrent callers", async () => {
+    let resolveTools: ((value: ToolSet) => void) | undefined;
+    const client = createMockClient(
+      new Promise<ToolSet>((resolve) => {
+        resolveTools = resolve;
+      })
+    );
+
+    loadMCPConfigMock.mockResolvedValue({
+      mcpServers: {
+        alpha: { url: "https://alpha.example.com/mcp" },
+      },
+    });
+    createMCPClientMock.mockResolvedValue(client);
+    mergeMCPToolsMock.mockReturnValue({
+      tools: createToolSet("alpha_tool"),
+      conflicts: [],
+    });
+
+    const manager = new MCPManager();
+    const firstInit = manager.init();
+    const secondInit = manager.init();
+
+    expect(firstInit).toBe(secondInit);
+    resolveTools?.(createToolSet("alpha_tool"));
+    await Promise.all([firstInit, secondInit]);
+
+    expect(createMCPClientMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("init() rejects after close() has been called", async () => {
+    const manager = new MCPManager();
+
+    await manager.close();
+
+    await expect(manager.init()).rejects.toThrow(CLOSED_ERROR_PATTERN);
   });
 
   it("init() with no .mcp.json returns empty tools without error", async () => {
@@ -320,6 +363,35 @@ describe("MCPManager", () => {
       { name: "alpha", status: "connected", toolCount: 2 },
       { name: "beta", status: "connected", toolCount: 1 },
     ]);
+  });
+
+  it("toolsByServer() returns per-server tool sets after init", async () => {
+    const alphaTools = createToolSet("alpha_tool");
+    const betaTools = createToolSet("beta_tool");
+    const alphaClient = createMockClient(alphaTools);
+    const betaClient = createMockClient(betaTools);
+
+    loadMCPConfigMock.mockResolvedValue({
+      mcpServers: {
+        alpha: { url: "https://alpha.example.com/mcp" },
+        beta: { url: "https://beta.example.com/mcp" },
+      },
+    });
+    createMCPClientMock
+      .mockResolvedValueOnce(alphaClient)
+      .mockResolvedValueOnce(betaClient);
+    mergeMCPToolsMock.mockReturnValue({
+      tools: { ...alphaTools, ...betaTools },
+      conflicts: [],
+    });
+
+    const manager = new MCPManager();
+    await manager.init();
+
+    expect(manager.toolsByServer()).toEqual({
+      alpha: alphaTools,
+      beta: betaTools,
+    });
   });
 
   it("tools() before init() throws error containing not initialized", () => {

--- a/packages/harness/src/mcp-manager.ts
+++ b/packages/harness/src/mcp-manager.ts
@@ -69,7 +69,10 @@ export class MCPManager {
       const config = await loadMCPConfig({
         configPath: this.options.configPath,
       });
-      const serverEntries = Object.entries(config.mcpServers);
+      const serverEntries = Object.entries({
+        ...config.mcpServers,
+        ...this.options.servers,
+      });
       const mcpTools: Record<string, ToolSet> = {};
 
       const connectionResults = await Promise.allSettled(

--- a/packages/harness/src/mcp-manager.ts
+++ b/packages/harness/src/mcp-manager.ts
@@ -68,6 +68,7 @@ export class MCPManager {
     try {
       const shouldLoadFile =
         this.options.configPath !== undefined ||
+        this.options.loadFileConfig === true ||
         this.options.servers === undefined ||
         Object.keys(this.options.servers).length === 0;
 

--- a/packages/harness/src/mcp-manager.ts
+++ b/packages/harness/src/mcp-manager.ts
@@ -23,22 +23,47 @@ export class MCPManager {
   private readonly options: MCPManagerOptions;
   private clients: ManagedClient[] = [];
   private mergedTools: ToolSet = {};
+  private mcpToolsByServer: Record<string, ToolSet> = {};
   private readonly statuses = new Map<string, MCPServerStatus>();
   private initialized = false;
-  private initializing = false;
   private closed = false;
+  private initPromise: Promise<void> | null = null;
 
   constructor(options: MCPManagerOptions = {}) {
     this.options = options;
   }
 
-  async init(): Promise<void> {
-    if (this.initialized || this.initializing) {
-      return;
+  init(): Promise<void> {
+    if (this.initialized) {
+      return Promise.resolve();
     }
 
-    this.initializing = true;
-    this.closed = false;
+    if (this.initPromise) {
+      return this.initPromise;
+    }
+
+    if (this.closed) {
+      return Promise.reject(
+        new Error("MCPManager has been closed. Create a new instance.")
+      );
+    }
+
+    this.initPromise = this.doInit();
+    return this.initPromise;
+  }
+
+  toolsByServer(): Record<string, ToolSet> {
+    if (!this.initialized) {
+      throw new Error("MCPManager not initialized. Call init() first.");
+    }
+
+    return { ...this.mcpToolsByServer };
+  }
+
+  private async doInit(): Promise<void> {
+    if (this.closed) {
+      throw new Error("MCPManager has been closed. Create a new instance.");
+    }
 
     try {
       const config = await loadMCPConfig({
@@ -68,15 +93,30 @@ export class MCPManager {
 
         const { client } = result.value;
         this.clients.push({ name: serverName, client });
+      }
 
-        const toolSet = await this.getToolsWithTimeout(serverName, client);
-        if (!toolSet) {
+      if (this.closed) {
+        await this.close();
+        throw new Error("MCPManager has been closed. Create a new instance.");
+      }
+
+      const connectedClients = this.clients;
+      const toolResults = await Promise.allSettled(
+        connectedClients.map(async ({ name, client }) => {
+          const toolSet = await this.getToolsWithTimeout(name, client);
+          return { name, toolSet };
+        })
+      );
+
+      for (const result of toolResults) {
+        if (result.status !== "fulfilled" || !result.value.toolSet) {
           continue;
         }
 
-        mcpTools[serverName] = toolSet;
-        this.statuses.set(serverName, {
-          name: serverName,
+        const { name, toolSet } = result.value;
+        mcpTools[name] = toolSet;
+        this.statuses.set(name, {
+          name,
           status: "connected",
           toolCount: Object.keys(toolSet).length,
         });
@@ -93,9 +133,10 @@ export class MCPManager {
       });
 
       this.mergedTools = mergeResult.tools;
+      this.mcpToolsByServer = mcpTools;
       this.initialized = true;
     } finally {
-      this.initializing = false;
+      this.initPromise = null;
     }
   }
 
@@ -117,6 +158,8 @@ export class MCPManager {
     }
 
     this.closed = true;
+    this.initialized = false;
+    this.initPromise = null;
 
     await Promise.allSettled(
       this.clients.map(async ({ name, client }) => {
@@ -133,6 +176,8 @@ export class MCPManager {
     );
 
     this.clients = [];
+    this.mergedTools = {};
+    this.mcpToolsByServer = {};
   }
 
   private async connectServer(

--- a/packages/harness/src/mcp-manager.ts
+++ b/packages/harness/src/mcp-manager.ts
@@ -95,11 +95,20 @@ export class MCPManager {
         }
 
         const { client } = result.value;
-        this.clients.push({ name: serverName, client });
+        if (this.closed) {
+          client.close().catch(() => undefined);
+        } else {
+          this.clients.push({ name: serverName, client });
+        }
       }
 
       if (this.closed) {
-        await this.close();
+        await Promise.allSettled(
+          this.clients.map(({ client }) =>
+            client.close().catch(() => undefined)
+          )
+        );
+        this.clients = [];
         throw new Error("MCPManager has been closed. Create a new instance.");
       }
 

--- a/packages/harness/src/mcp-manager.ts
+++ b/packages/harness/src/mcp-manager.ts
@@ -15,8 +15,8 @@ const DEFAULT_TOOLS_TIMEOUT_MS = 30_000;
 type MCPClient = Awaited<ReturnType<typeof createMCPClient>>;
 
 interface ManagedClient {
-  name: string;
   client: MCPClient;
+  name: string;
 }
 
 export class MCPManager {

--- a/packages/harness/src/mcp-manager.ts
+++ b/packages/harness/src/mcp-manager.ts
@@ -60,95 +60,26 @@ export class MCPManager {
     return { ...this.mcpToolsByServer };
   }
 
-  private async doInit(): Promise<void> {
+  private throwIfClosed(): void {
     if (this.closed) {
       throw new Error("MCPManager has been closed. Create a new instance.");
     }
+  }
+
+  private async doInit(): Promise<void> {
+    this.throwIfClosed();
 
     try {
-      const shouldLoadFile =
-        this.options.configPath !== undefined ||
-        this.options.loadFileConfig === true ||
-        this.options.servers === undefined ||
-        Object.keys(this.options.servers).length === 0;
-
-      const fileServers = shouldLoadFile
-        ? (
-            await loadMCPConfig(
-              this.options.configPath
-                ? { configPath: this.options.configPath }
-                : undefined
-            )
-          ).mcpServers
-        : {};
-
-      const serverEntries = Object.entries({
-        ...fileServers,
-        ...this.options.servers,
-      });
+      const serverEntries = await this.resolveServerEntries();
       const mcpTools: Record<string, ToolSet> = {};
 
-      const connectionResults = await Promise.allSettled(
-        serverEntries.map(async ([name, serverConfig]) => {
-          const client = await this.connectServer(name, serverConfig);
-          return { name, client };
-        })
-      );
+      await this.connectAllServers(serverEntries);
+      this.throwIfClosed();
 
-      const lateClients: MCPClient[] = [];
+      const toolResults = await this.fetchAllTools();
+      this.throwIfClosed();
 
-      for (const [index, result] of connectionResults.entries()) {
-        const [serverName] = serverEntries[index] ?? [];
-
-        if (!serverName) {
-          continue;
-        }
-
-        if (result.status === "rejected") {
-          this.recordFailure(serverName, result.reason);
-          continue;
-        }
-
-        const { client } = result.value;
-        if (this.closed) {
-          lateClients.push(client);
-        } else {
-          this.clients.push({ name: serverName, client });
-        }
-      }
-
-      if (this.closed) {
-        await Promise.allSettled([
-          ...this.clients.map(({ client }) =>
-            client.close().catch(() => undefined)
-          ),
-          ...lateClients.map((client) => client.close().catch(() => undefined)),
-        ]);
-        this.clients = [];
-        throw new Error("MCPManager has been closed. Create a new instance.");
-      }
-
-      const connectedClients = this.clients;
-      const toolResults = await Promise.allSettled(
-        connectedClients.map(async ({ name, client }) => {
-          const toolSet = await this.getToolsWithTimeout(name, client);
-          return { name, toolSet };
-        })
-      );
-
-      for (const result of toolResults) {
-        if (result.status !== "fulfilled" || !result.value.toolSet) {
-          continue;
-        }
-
-        const { name, toolSet } = result.value;
-        mcpTools[name] = toolSet;
-        this.statuses.set(name, {
-          name,
-          status: "connected",
-          toolCount: Object.keys(toolSet).length,
-        });
-      }
+      this.applyToolResults(toolResults, mcpTools);
 
       const mergeResult = mergeMCPTools({
         localTools: {},
@@ -165,6 +96,106 @@ export class MCPManager {
       this.initialized = true;
     } finally {
       this.initPromise = null;
+    }
+  }
+
+  private async resolveServerEntries(): Promise<[string, MCPServerConfig][]> {
+    const shouldLoadFile =
+      this.options.configPath !== undefined ||
+      this.options.loadFileConfig === true ||
+      this.options.servers === undefined ||
+      Object.keys(this.options.servers).length === 0;
+
+    const fileServers = shouldLoadFile
+      ? (
+          await loadMCPConfig(
+            this.options.configPath
+              ? { configPath: this.options.configPath }
+              : undefined
+          )
+        ).mcpServers
+      : {};
+
+    return Object.entries({
+      ...fileServers,
+      ...this.options.servers,
+    });
+  }
+
+  private async connectAllServers(
+    serverEntries: [string, MCPServerConfig][]
+  ): Promise<void> {
+    const connectionResults = await Promise.allSettled(
+      serverEntries.map(async ([name, serverConfig]) => {
+        const client = await this.connectServer(name, serverConfig);
+        return { name, client };
+      })
+    );
+
+    const lateClients: MCPClient[] = [];
+
+    for (const [index, result] of connectionResults.entries()) {
+      const [serverName] = serverEntries[index] ?? [];
+
+      if (!serverName) {
+        continue;
+      }
+
+      if (result.status === "rejected") {
+        this.recordFailure(serverName, result.reason);
+        continue;
+      }
+
+      const { client } = result.value;
+      if (this.closed) {
+        lateClients.push(client);
+      } else {
+        this.clients.push({ name: serverName, client });
+      }
+    }
+
+    if (this.closed) {
+      await Promise.allSettled([
+        ...this.clients.map(({ client }) =>
+          client.close().catch(() => undefined)
+        ),
+        ...lateClients.map((client) => client.close().catch(() => undefined)),
+      ]);
+      this.clients = [];
+      throw new Error("MCPManager has been closed. Create a new instance.");
+    }
+  }
+
+  private fetchAllTools(): Promise<
+    PromiseSettledResult<{ name: string; toolSet: ToolSet | null }>[]
+  > {
+    return Promise.allSettled(
+      this.clients.map(async ({ name, client }) => {
+        const toolSet = await this.getToolsWithTimeout(name, client);
+        return { name, toolSet };
+      })
+    );
+  }
+
+  private applyToolResults(
+    toolResults: PromiseSettledResult<{
+      name: string;
+      toolSet: ToolSet | null;
+    }>[],
+    mcpTools: Record<string, ToolSet>
+  ): void {
+    for (const result of toolResults) {
+      if (result.status !== "fulfilled" || !result.value.toolSet) {
+        continue;
+      }
+
+      const { name, toolSet } = result.value;
+      mcpTools[name] = toolSet;
+      this.statuses.set(name, {
+        name,
+        status: "connected",
+        toolCount: Object.keys(toolSet).length,
+      });
     }
   }
 

--- a/packages/harness/src/mcp-manager.ts
+++ b/packages/harness/src/mcp-manager.ts
@@ -66,11 +66,23 @@ export class MCPManager {
     }
 
     try {
-      const config = await loadMCPConfig({
-        configPath: this.options.configPath,
-      });
+      const shouldLoadFile =
+        this.options.configPath !== undefined ||
+        this.options.servers === undefined ||
+        Object.keys(this.options.servers).length === 0;
+
+      const fileServers = shouldLoadFile
+        ? (
+            await loadMCPConfig(
+              this.options.configPath
+                ? { configPath: this.options.configPath }
+                : undefined
+            )
+          ).mcpServers
+        : {};
+
       const serverEntries = Object.entries({
-        ...config.mcpServers,
+        ...fileServers,
         ...this.options.servers,
       });
       const mcpTools: Record<string, ToolSet> = {};
@@ -81,6 +93,8 @@ export class MCPManager {
           return { name, client };
         })
       );
+
+      const lateClients: MCPClient[] = [];
 
       for (const [index, result] of connectionResults.entries()) {
         const [serverName] = serverEntries[index] ?? [];
@@ -96,18 +110,19 @@ export class MCPManager {
 
         const { client } = result.value;
         if (this.closed) {
-          client.close().catch(() => undefined);
+          lateClients.push(client);
         } else {
           this.clients.push({ name: serverName, client });
         }
       }
 
       if (this.closed) {
-        await Promise.allSettled(
-          this.clients.map(({ client }) =>
+        await Promise.allSettled([
+          ...this.clients.map(({ client }) =>
             client.close().catch(() => undefined)
-          )
-        );
+          ),
+          ...lateClients.map((client) => client.close().catch(() => undefined)),
+        ]);
         this.clients = [];
         throw new Error("MCPManager has been closed. Create a new instance.");
       }

--- a/packages/harness/src/mcp-manager.ts
+++ b/packages/harness/src/mcp-manager.ts
@@ -1,0 +1,203 @@
+import { createMCPClient } from "@ai-sdk/mcp";
+import { Experimental_StdioMCPTransport } from "@ai-sdk/mcp/mcp-stdio";
+import type { ToolSet } from "ai";
+
+import { isStdioConfig, loadMCPConfig } from "./mcp-config.js";
+import { mergeMCPTools } from "./mcp-tool-merger.js";
+import type {
+  MCPManagerOptions,
+  MCPServerConfig,
+  MCPServerStatus,
+} from "./mcp-types.js";
+
+const DEFAULT_TOOLS_TIMEOUT_MS = 30_000;
+
+type MCPClient = Awaited<ReturnType<typeof createMCPClient>>;
+
+interface ManagedClient {
+  name: string;
+  client: MCPClient;
+}
+
+export class MCPManager {
+  private readonly options: MCPManagerOptions;
+  private clients: ManagedClient[] = [];
+  private mergedTools: ToolSet = {};
+  private readonly statuses = new Map<string, MCPServerStatus>();
+  private initialized = false;
+  private initializing = false;
+  private closed = false;
+
+  constructor(options: MCPManagerOptions = {}) {
+    this.options = options;
+  }
+
+  async init(): Promise<void> {
+    if (this.initialized || this.initializing) {
+      return;
+    }
+
+    this.initializing = true;
+    this.closed = false;
+
+    try {
+      const config = await loadMCPConfig({
+        configPath: this.options.configPath,
+      });
+      const serverEntries = Object.entries(config.mcpServers);
+      const mcpTools: Record<string, ToolSet> = {};
+
+      const connectionResults = await Promise.allSettled(
+        serverEntries.map(async ([name, serverConfig]) => {
+          const client = await this.connectServer(name, serverConfig);
+          return { name, client };
+        })
+      );
+
+      for (const [index, result] of connectionResults.entries()) {
+        const [serverName] = serverEntries[index] ?? [];
+
+        if (!serverName) {
+          continue;
+        }
+
+        if (result.status === "rejected") {
+          this.recordFailure(serverName, result.reason);
+          continue;
+        }
+
+        const { client } = result.value;
+        this.clients.push({ name: serverName, client });
+
+        const toolSet = await this.getToolsWithTimeout(serverName, client);
+        if (!toolSet) {
+          continue;
+        }
+
+        mcpTools[serverName] = toolSet;
+        this.statuses.set(serverName, {
+          name: serverName,
+          status: "connected",
+          toolCount: Object.keys(toolSet).length,
+        });
+      }
+
+      const mergeResult = mergeMCPTools({
+        localTools: {},
+        mcpTools,
+        onConflict: (conflict) => {
+          console.warn(
+            `[MCP] Tool name conflict: "${conflict.toolName}" from servers: ${conflict.sources.join(", ")}`
+          );
+        },
+      });
+
+      this.mergedTools = mergeResult.tools;
+      this.initialized = true;
+    } finally {
+      this.initializing = false;
+    }
+  }
+
+  tools(): ToolSet {
+    if (!this.initialized) {
+      throw new Error("MCPManager not initialized. Call init() first.");
+    }
+
+    return this.mergedTools;
+  }
+
+  status(): MCPServerStatus[] {
+    return Array.from(this.statuses.values()).map((entry) => ({ ...entry }));
+  }
+
+  async close(): Promise<void> {
+    if (this.closed) {
+      return;
+    }
+
+    this.closed = true;
+
+    await Promise.allSettled(
+      this.clients.map(async ({ name, client }) => {
+        try {
+          await client.close();
+          const status = this.statuses.get(name);
+          if (status) {
+            this.statuses.set(name, { ...status, status: "closed" });
+          }
+        } catch {
+          return;
+        }
+      })
+    );
+
+    this.clients = [];
+  }
+
+  private async connectServer(
+    name: string,
+    config: MCPServerConfig
+  ): Promise<MCPClient> {
+    if (isStdioConfig(config)) {
+      const transport = new Experimental_StdioMCPTransport({
+        command: config.command,
+        args: config.args,
+        env: config.env,
+      });
+
+      return await createMCPClient({
+        transport,
+        onUncaughtError: (error) => {
+          this.options.onError?.(name, error);
+        },
+      });
+    }
+
+    return await createMCPClient({
+      transport: {
+        type: "http",
+        url: config.url,
+        headers: config.headers,
+      },
+      onUncaughtError: (error) => {
+        this.options.onError?.(name, error);
+      },
+    });
+  }
+
+  private async getToolsWithTimeout(
+    name: string,
+    client: MCPClient
+  ): Promise<ToolSet | null> {
+    const timeout = this.options.toolsTimeout ?? DEFAULT_TOOLS_TIMEOUT_MS;
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), timeout);
+
+    try {
+      const timeoutPromise = new Promise<never>((_, reject) => {
+        controller.signal.addEventListener("abort", () => {
+          reject(new Error(`Tools fetch timed out after ${timeout}ms`));
+        });
+      });
+
+      const tools = await Promise.race([client.tools(), timeoutPromise]);
+      return tools as ToolSet;
+    } catch (error) {
+      this.recordFailure(name, error);
+      return null;
+    } finally {
+      clearTimeout(timer);
+    }
+  }
+
+  private recordFailure(name: string, error: unknown): void {
+    this.statuses.set(name, {
+      name,
+      status: "failed",
+      toolCount: 0,
+      error: String(error),
+    });
+    this.options.onError?.(name, error);
+  }
+}

--- a/packages/harness/src/mcp-manager.ts
+++ b/packages/harness/src/mcp-manager.ts
@@ -156,7 +156,7 @@ export class MCPManager {
 
     return await createMCPClient({
       transport: {
-        type: "http",
+        type: config.type ?? "http",
         url: config.url,
         headers: config.headers,
       },

--- a/packages/harness/src/mcp-tool-merger.test.ts
+++ b/packages/harness/src/mcp-tool-merger.test.ts
@@ -183,4 +183,23 @@ describe("mergeMCPTools", () => {
       sources: ["local", "filesystem"],
     });
   });
+
+  it("adds numeric suffixes when sanitized server prefixes would collide", () => {
+    const result = mergeMCPTools({
+      localTools: { toolname: mockTool },
+      mcpTools: {
+        "my-server": { toolname: mockTool },
+        my_server: { toolname: mockTool },
+      },
+    });
+
+    expect(result.tools).toEqual({
+      toolname: mockTool,
+      my_server_toolname: mockTool,
+      my_server_toolname_2: mockTool,
+    });
+    expect(result.conflicts).toEqual([
+      { toolName: "toolname", sources: ["local", "my-server", "my_server"] },
+    ]);
+  });
 });

--- a/packages/harness/src/mcp-tool-merger.test.ts
+++ b/packages/harness/src/mcp-tool-merger.test.ts
@@ -1,0 +1,186 @@
+import type { Tool } from "ai";
+import { describe, expect, it, vi } from "vitest";
+import { mergeMCPTools, sanitizeServerName } from "./mcp-tool-merger";
+
+const mockTool = { description: "test", parameters: {} } as unknown as Tool;
+
+describe("sanitizeServerName", () => {
+  it("replaces special characters with underscores", () => {
+    expect(sanitizeServerName("my-server.io")).toBe("my_server_io");
+  });
+});
+
+describe("mergeMCPTools", () => {
+  it("merges without conflicts when tool names are unique", () => {
+    const localTools = { local_tool: mockTool };
+    const mcpTools = {
+      serverA: { remote_tool: mockTool },
+      serverB: { another_remote_tool: mockTool },
+    };
+
+    const result = mergeMCPTools({ localTools, mcpTools });
+
+    expect(result.tools).toEqual({
+      local_tool: mockTool,
+      remote_tool: mockTool,
+      another_remote_tool: mockTool,
+    });
+    expect(result.conflicts).toEqual([]);
+    expect(result.tools).not.toBe(localTools);
+    expect(result.tools).not.toBe(mcpTools.serverA);
+  });
+
+  it("prefixes conflicting MCP tool when local tool has the same name", () => {
+    const onConflict = vi.fn();
+
+    const result = mergeMCPTools({
+      localTools: { read_file: mockTool },
+      mcpTools: { filesystem: { read_file: mockTool } },
+      onConflict,
+    });
+
+    expect(result.tools).toEqual({
+      read_file: mockTool,
+      filesystem_read_file: mockTool,
+    });
+    expect(result.conflicts).toEqual([
+      { toolName: "read_file", sources: ["local", "filesystem"] },
+    ]);
+    expect(onConflict).toHaveBeenCalledTimes(1);
+    expect(onConflict).toHaveBeenCalledWith({
+      toolName: "read_file",
+      sources: ["local", "filesystem"],
+    });
+  });
+
+  it("prefixes both MCP tools when two servers expose the same tool name", () => {
+    const onConflict = vi.fn();
+
+    const result = mergeMCPTools({
+      localTools: {},
+      mcpTools: {
+        github: { search: mockTool },
+        gitlab: { search: mockTool },
+      },
+      onConflict,
+    });
+
+    expect(result.tools).toEqual({
+      github_search: mockTool,
+      gitlab_search: mockTool,
+    });
+    expect(result.conflicts).toEqual([
+      { toolName: "search", sources: ["github", "gitlab"] },
+    ]);
+    expect(onConflict).toHaveBeenCalledTimes(1);
+    expect(onConflict).toHaveBeenCalledWith({
+      toolName: "search",
+      sources: ["github", "gitlab"],
+    });
+  });
+
+  it("returns local tools unchanged when there are no MCP tools", () => {
+    const localTools = { local_tool: mockTool };
+
+    const result = mergeMCPTools({
+      localTools,
+      mcpTools: {},
+    });
+
+    expect(result.tools).toEqual({ local_tool: mockTool });
+    expect(result.conflicts).toEqual([]);
+    expect(result.tools).not.toBe(localTools);
+  });
+
+  it("returns MCP tools as-is when there are no local tools and no conflicts", () => {
+    const result = mergeMCPTools({
+      localTools: {},
+      mcpTools: {
+        alpha: { tool_one: mockTool },
+        beta: { tool_two: mockTool },
+      },
+    });
+
+    expect(result.tools).toEqual({
+      tool_one: mockTool,
+      tool_two: mockTool,
+    });
+    expect(result.conflicts).toEqual([]);
+  });
+
+  it("returns empty tools and conflicts for empty inputs", () => {
+    const result = mergeMCPTools({
+      localTools: {},
+      mcpTools: {},
+    });
+
+    expect(result).toEqual({ tools: {}, conflicts: [] });
+  });
+
+  it("sanitizes server names before prefixing conflicting tool names", () => {
+    const result = mergeMCPTools({
+      localTools: { toolname: mockTool },
+      mcpTools: {
+        "my-server.io": { toolname: mockTool },
+      },
+    });
+
+    expect(result.tools).toEqual({
+      toolname: mockTool,
+      my_server_io_toolname: mockTool,
+    });
+    expect(result.conflicts).toEqual([
+      { toolName: "toolname", sources: ["local", "my-server.io"] },
+    ]);
+  });
+
+  it("prefixes all conflicting tools and reports each conflict once", () => {
+    const onConflict = vi.fn();
+
+    const result = mergeMCPTools({
+      localTools: {
+        read_file: mockTool,
+        list_dir: mockTool,
+      },
+      mcpTools: {
+        filesystem: {
+          read_file: mockTool,
+          list_dir: mockTool,
+          unique_tool: mockTool,
+        },
+        backup: {
+          read_file: mockTool,
+        },
+      },
+      onConflict,
+    });
+
+    expect(result.tools).toEqual({
+      read_file: mockTool,
+      list_dir: mockTool,
+      filesystem_read_file: mockTool,
+      filesystem_list_dir: mockTool,
+      unique_tool: mockTool,
+      backup_read_file: mockTool,
+    });
+    expect(result.conflicts).toEqual([
+      {
+        toolName: "read_file",
+        sources: ["local", "filesystem", "backup"],
+      },
+      {
+        toolName: "list_dir",
+        sources: ["local", "filesystem"],
+      },
+    ]);
+    expect(onConflict).toHaveBeenCalledTimes(2);
+    expect(onConflict).toHaveBeenNthCalledWith(1, {
+      toolName: "read_file",
+      sources: ["local", "filesystem", "backup"],
+    });
+    expect(onConflict).toHaveBeenNthCalledWith(2, {
+      toolName: "list_dir",
+      sources: ["local", "filesystem"],
+    });
+  });
+});

--- a/packages/harness/src/mcp-tool-merger.ts
+++ b/packages/harness/src/mcp-tool-merger.ts
@@ -17,6 +17,7 @@ export function mergeMCPTools(options: MergeOptions): MCPToolMergeResult {
 
   const localToolNames = new Set(Object.keys(localTools));
   const conflicts: Array<{ toolName: string; sources: string[] }> = [];
+  const processedConflicts = new Set<string>();
 
   const allMCPEntries: Array<{
     serverName: string;
@@ -50,7 +51,13 @@ export function mergeMCPTools(options: MergeOptions): MCPToolMergeResult {
     const conflictsWithOtherMCP = serversWithThisTool.length > 1;
 
     if (conflictsWithLocal || conflictsWithOtherMCP) {
-      const prefixedName = `${sanitizeServerName(serverName)}_${toolName}`;
+      const sanitizedServerName = sanitizeServerName(serverName);
+      let prefixedName = `${sanitizedServerName}_${toolName}`;
+      let suffix = 2;
+      while (prefixedName in mergedTools) {
+        prefixedName = `${sanitizedServerName}_${toolName}_${suffix}`;
+        suffix++;
+      }
       mergedTools[prefixedName] = tool;
 
       const sources = conflictsWithLocal
@@ -58,7 +65,8 @@ export function mergeMCPTools(options: MergeOptions): MCPToolMergeResult {
         : serversWithThisTool;
       const uniqueSources = [...new Set(sources)];
 
-      if (!conflicts.find((conflict) => conflict.toolName === toolName)) {
+      if (!processedConflicts.has(toolName)) {
+        processedConflicts.add(toolName);
         const conflict = { toolName, sources: uniqueSources };
         conflicts.push(conflict);
         onConflict?.(conflict);

--- a/packages/harness/src/mcp-tool-merger.ts
+++ b/packages/harness/src/mcp-tool-merger.ts
@@ -1,0 +1,77 @@
+import type { ToolSet } from "ai";
+import type { MCPToolMergeResult } from "./mcp-types.js";
+
+export interface ToolConflict {
+  toolName: string;
+  sources: string[];
+}
+
+export interface MergeOptions {
+  localTools: ToolSet;
+  mcpTools: Record<string, ToolSet>;
+  onConflict?: (conflict: ToolConflict) => void;
+}
+
+export function mergeMCPTools(options: MergeOptions): MCPToolMergeResult {
+  const { localTools, mcpTools, onConflict } = options;
+
+  const localToolNames = new Set(Object.keys(localTools));
+  const conflicts: Array<{ toolName: string; sources: string[] }> = [];
+
+  const allMCPEntries: Array<{
+    serverName: string;
+    toolName: string;
+    tool: ToolSet[string];
+  }> = [];
+
+  for (const [serverName, serverTools] of Object.entries(mcpTools)) {
+    for (const [toolName, tool] of Object.entries(serverTools)) {
+      allMCPEntries.push({
+        serverName,
+        toolName,
+        tool: tool as ToolSet[string],
+      });
+    }
+  }
+
+  const toolNameToServers = new Map<string, string[]>();
+
+  for (const entry of allMCPEntries) {
+    const existing = toolNameToServers.get(entry.toolName) ?? [];
+    toolNameToServers.set(entry.toolName, [...existing, entry.serverName]);
+  }
+
+  const mergedTools: ToolSet = { ...localTools };
+
+  for (const entry of allMCPEntries) {
+    const { serverName, toolName, tool } = entry;
+    const serversWithThisTool = toolNameToServers.get(toolName) ?? [];
+    const conflictsWithLocal = localToolNames.has(toolName);
+    const conflictsWithOtherMCP = serversWithThisTool.length > 1;
+
+    if (conflictsWithLocal || conflictsWithOtherMCP) {
+      const prefixedName = `${sanitizeServerName(serverName)}_${toolName}`;
+      mergedTools[prefixedName] = tool;
+
+      const sources = conflictsWithLocal
+        ? ["local", ...serversWithThisTool]
+        : serversWithThisTool;
+      const uniqueSources = [...new Set(sources)];
+
+      if (!conflicts.find((conflict) => conflict.toolName === toolName)) {
+        const conflict = { toolName, sources: uniqueSources };
+        conflicts.push(conflict);
+        onConflict?.(conflict);
+      }
+      continue;
+    }
+
+    mergedTools[toolName] = tool;
+  }
+
+  return { tools: mergedTools, conflicts };
+}
+
+export function sanitizeServerName(name: string): string {
+  return name.toLowerCase().replace(/[^a-z0-9_]/g, "_");
+}

--- a/packages/harness/src/mcp-tool-merger.ts
+++ b/packages/harness/src/mcp-tool-merger.ts
@@ -16,68 +16,100 @@ export function mergeMCPTools(options: MergeOptions): MCPToolMergeResult {
   const { localTools, mcpTools, onConflict } = options;
 
   const localToolNames = new Set(Object.keys(localTools));
+  const allMCPEntries = buildMCPEntries(mcpTools);
+  const toolNameToServers = buildServerIndex(allMCPEntries);
+
+  const mergedTools: ToolSet = { ...localTools };
+  const reservedKeys = new Set(Object.keys(localTools));
   const conflicts: Array<{ toolName: string; sources: string[] }> = [];
   const processedConflicts = new Set<string>();
 
-  const allMCPEntries: Array<{
+  for (const { serverName, toolName, tool } of allMCPEntries) {
+    const serversWithThisTool = toolNameToServers.get(toolName) ?? [];
+    const hasConflict =
+      localToolNames.has(toolName) || serversWithThisTool.length > 1;
+
+    if (hasConflict) {
+      const alias = resolveAlias(serverName, toolName, reservedKeys);
+      mergedTools[alias] = tool;
+      reservedKeys.add(alias);
+      recordConflict(
+        toolName,
+        serverName,
+        serversWithThisTool,
+        localToolNames,
+        processedConflicts,
+        conflicts,
+        onConflict
+      );
+    } else if (!reservedKeys.has(toolName)) {
+      mergedTools[toolName] = tool;
+      reservedKeys.add(toolName);
+    }
+  }
+
+  return { tools: mergedTools, conflicts };
+}
+
+function buildMCPEntries(
+  mcpTools: Record<string, ToolSet>
+): Array<{ serverName: string; toolName: string; tool: ToolSet[string] }> {
+  const entries: Array<{
     serverName: string;
     toolName: string;
     tool: ToolSet[string];
   }> = [];
-
   for (const [serverName, serverTools] of Object.entries(mcpTools)) {
     for (const [toolName, tool] of Object.entries(serverTools)) {
-      allMCPEntries.push({
-        serverName,
-        toolName,
-        tool: tool as ToolSet[string],
-      });
+      entries.push({ serverName, toolName, tool: tool as ToolSet[string] });
     }
   }
+  return entries;
+}
 
-  const toolNameToServers = new Map<string, string[]>();
-
-  for (const entry of allMCPEntries) {
-    const existing = toolNameToServers.get(entry.toolName) ?? [];
-    toolNameToServers.set(entry.toolName, [...existing, entry.serverName]);
+function buildServerIndex(
+  entries: Array<{ serverName: string; toolName: string }>
+): Map<string, string[]> {
+  const index = new Map<string, string[]>();
+  for (const { toolName, serverName } of entries) {
+    index.set(toolName, [...(index.get(toolName) ?? []), serverName]);
   }
+  return index;
+}
 
-  const mergedTools: ToolSet = { ...localTools };
-
-  for (const entry of allMCPEntries) {
-    const { serverName, toolName, tool } = entry;
-    const serversWithThisTool = toolNameToServers.get(toolName) ?? [];
-    const conflictsWithLocal = localToolNames.has(toolName);
-    const conflictsWithOtherMCP = serversWithThisTool.length > 1;
-
-    if (conflictsWithLocal || conflictsWithOtherMCP) {
-      const sanitizedServerName = sanitizeServerName(serverName);
-      let prefixedName = `${sanitizedServerName}_${toolName}`;
-      let suffix = 2;
-      while (prefixedName in mergedTools) {
-        prefixedName = `${sanitizedServerName}_${toolName}_${suffix}`;
-        suffix++;
-      }
-      mergedTools[prefixedName] = tool;
-
-      const sources = conflictsWithLocal
-        ? ["local", ...serversWithThisTool]
-        : serversWithThisTool;
-      const uniqueSources = [...new Set(sources)];
-
-      if (!processedConflicts.has(toolName)) {
-        processedConflicts.add(toolName);
-        const conflict = { toolName, sources: uniqueSources };
-        conflicts.push(conflict);
-        onConflict?.(conflict);
-      }
-      continue;
-    }
-
-    mergedTools[toolName] = tool;
+function resolveAlias(
+  serverName: string,
+  toolName: string,
+  reservedKeys: Set<string>
+): string {
+  const prefix = sanitizeServerName(serverName);
+  let alias = `${prefix}_${toolName}`;
+  let suffix = 2;
+  while (reservedKeys.has(alias)) {
+    alias = `${prefix}_${toolName}_${suffix++}`;
   }
+  return alias;
+}
 
-  return { tools: mergedTools, conflicts };
+function recordConflict(
+  toolName: string,
+  _serverName: string,
+  serversWithTool: string[],
+  localToolNames: Set<string>,
+  processedConflicts: Set<string>,
+  conflicts: Array<{ toolName: string; sources: string[] }>,
+  onConflict?: (conflict: ToolConflict) => void
+): void {
+  if (processedConflicts.has(toolName)) {
+    return;
+  }
+  processedConflicts.add(toolName);
+  const sources = localToolNames.has(toolName)
+    ? ["local", ...serversWithTool]
+    : serversWithTool;
+  const conflict = { toolName, sources: [...new Set(sources)] };
+  conflicts.push(conflict);
+  onConflict?.(conflict);
 }
 
 export function sanitizeServerName(name: string): string {

--- a/packages/harness/src/mcp-tool-merger.ts
+++ b/packages/harness/src/mcp-tool-merger.ts
@@ -42,9 +42,12 @@ export function mergeMCPTools(options: MergeOptions): MCPToolMergeResult {
         conflicts,
         onConflict
       );
-    } else if (!reservedKeys.has(toolName)) {
-      mergedTools[toolName] = tool;
-      reservedKeys.add(toolName);
+    } else {
+      const key = reservedKeys.has(toolName)
+        ? resolveAlias(serverName, toolName, reservedKeys)
+        : toolName;
+      mergedTools[key] = tool;
+      reservedKeys.add(key);
     }
   }
 

--- a/packages/harness/src/mcp-tool-merger.ts
+++ b/packages/harness/src/mcp-tool-merger.ts
@@ -2,8 +2,8 @@ import type { ToolSet } from "ai";
 import type { MCPToolMergeResult } from "./mcp-types.js";
 
 export interface ToolConflict {
-  toolName: string;
   sources: string[];
+  toolName: string;
 }
 
 export interface MergeOptions {

--- a/packages/harness/src/mcp-types.ts
+++ b/packages/harness/src/mcp-types.ts
@@ -1,0 +1,87 @@
+/**
+ * @module mcp-types
+ * Pure TypeScript type definitions for MCP client integration.
+ * No runtime logic, no imports from @ai-sdk/mcp.
+ */
+
+import type { ToolSet } from "ai";
+
+/**
+ * Configuration for a stdio-based MCP server.
+ * The server is launched as a subprocess with the given command and arguments.
+ */
+export interface MCPStdioServerConfig {
+  /** The executable command to run (e.g., "python", "node", "/usr/local/bin/my-server") */
+  command: string;
+  /** Optional arguments to pass to the command */
+  args?: string[];
+  /** Optional environment variables to pass to the subprocess */
+  env?: Record<string, string>;
+}
+
+/**
+ * Configuration for an HTTP/SSE-based MCP server.
+ * The server is accessed via HTTP at the given URL.
+ */
+export interface MCPRemoteServerConfig {
+  /** The base URL of the remote MCP server (e.g., "http://localhost:3000", "https://api.example.com") */
+  url: string;
+  /** Optional HTTP headers to include in requests (e.g., authorization, custom headers) */
+  headers?: Record<string, string>;
+}
+
+/**
+ * Configuration for an MCP server.
+ * Discriminated union: either stdio (launches a subprocess) or remote (HTTP/SSE).
+ */
+export type MCPServerConfig = MCPStdioServerConfig | MCPRemoteServerConfig;
+
+/**
+ * MCP servers configuration file structure.
+ * Typically stored as `.mcp.json` in the project root.
+ */
+export interface MCPConfigFile {
+  /** Map of server names to their configurations */
+  mcpServers: Record<string, MCPServerConfig>;
+}
+
+/**
+ * Options for initializing and managing MCP servers.
+ */
+export interface MCPManagerOptions {
+  /** Path to the MCP configuration file (e.g., "./.mcp.json" or "/etc/app/.mcp.json") */
+  configPath?: string;
+  /** Optional callback for server errors (connection failures, crashes, etc.) */
+  onError?: (server: string, error: unknown) => void;
+  /** Timeout (in milliseconds) for tool execution requests to MCP servers (default: 30000) */
+  toolsTimeout?: number;
+}
+
+/**
+ * Result of merging tools from multiple MCP servers.
+ */
+export interface MCPToolMergeResult {
+  /** Merged set of tools from all connected servers */
+  tools: ToolSet;
+  /** List of tool name conflicts detected during merge */
+  conflicts: Array<{
+    /** The conflicting tool name */
+    toolName: string;
+    /** List of server names that provided this tool */
+    sources: string[];
+  }>;
+}
+
+/**
+ * Status information for a connected MCP server.
+ */
+export interface MCPServerStatus {
+  /** Name of the server (key in the MCP config) */
+  name: string;
+  /** Current connection state */
+  status: "connected" | "failed" | "closed";
+  /** Number of tools provided by this server */
+  toolCount: number;
+  /** Error message if status is "failed" (e.g., connection refused, timeout) */
+  error?: string;
+}

--- a/packages/harness/src/mcp-types.ts
+++ b/packages/harness/src/mcp-types.ts
@@ -61,9 +61,17 @@ export interface MCPManagerOptions {
   loadFileConfig?: boolean;
   /** Optional callback for server errors (connection failures, crashes, etc.) */
   onError?: (server: string, error: unknown) => void;
-  /** Inline server configurations merged with any file-based config */
+  /**
+   * Inline server configurations.
+   * By default, providing `servers` does not load `.mcp.json` automatically; file-based
+   * config is only loaded and merged when `loadFileConfig` is true or `configPath` is set.
+   */
   servers?: Record<string, MCPServerConfig>;
-  /** Timeout (in milliseconds) for tool execution requests to MCP servers (default: 30000) */
+  /**
+   * Timeout (in milliseconds) for fetching/listing tool schemas from MCP servers
+   * during initialization (default: 30000).
+   * This option does not apply a timeout to individual tool-call execution.
+   */
   toolsTimeout?: number;
 }
 

--- a/packages/harness/src/mcp-types.ts
+++ b/packages/harness/src/mcp-types.ts
@@ -26,6 +26,8 @@ export interface MCPStdioServerConfig {
 export interface MCPRemoteServerConfig {
   /** The base URL of the remote MCP server (e.g., "http://localhost:3000", "https://api.example.com") */
   url: string;
+  /** Transport type: 'http' (Streamable HTTP, default) or 'sse' (Server-Sent Events) */
+  type?: "http" | "sse";
   /** Optional HTTP headers to include in requests (e.g., authorization, custom headers) */
   headers?: Record<string, string>;
 }

--- a/packages/harness/src/mcp-types.ts
+++ b/packages/harness/src/mcp-types.ts
@@ -53,6 +53,12 @@ export interface MCPConfigFile {
 export interface MCPManagerOptions {
   /** Path to the MCP configuration file (e.g., "./.mcp.json" or "/etc/app/.mcp.json") */
   configPath?: string;
+  /**
+   * When true, always load file-based config even when inline `servers` are provided.
+   * Use this when `configPath` is undefined (default `.mcp.json`) but file servers
+   * should still be merged with inline servers.
+   */
+  loadFileConfig?: boolean;
   /** Optional callback for server errors (connection failures, crashes, etc.) */
   onError?: (server: string, error: unknown) => void;
   /** Inline server configurations merged with any file-based config */

--- a/packages/harness/src/mcp-types.ts
+++ b/packages/harness/src/mcp-types.ts
@@ -55,6 +55,8 @@ export interface MCPManagerOptions {
   configPath?: string;
   /** Optional callback for server errors (connection failures, crashes, etc.) */
   onError?: (server: string, error: unknown) => void;
+  /** Inline server configurations merged with any file-based config */
+  servers?: Record<string, MCPServerConfig>;
   /** Timeout (in milliseconds) for tool execution requests to MCP servers (default: 30000) */
   toolsTimeout?: number;
 }

--- a/packages/harness/src/mcp-types.ts
+++ b/packages/harness/src/mcp-types.ts
@@ -11,10 +11,10 @@ import type { ToolSet } from "ai";
  * The server is launched as a subprocess with the given command and arguments.
  */
 export interface MCPStdioServerConfig {
-  /** The executable command to run (e.g., "python", "node", "/usr/local/bin/my-server") */
-  command: string;
   /** Optional arguments to pass to the command */
   args?: string[];
+  /** The executable command to run (e.g., "python", "node", "/usr/local/bin/my-server") */
+  command: string;
   /** Optional environment variables to pass to the subprocess */
   env?: Record<string, string>;
 }
@@ -24,12 +24,12 @@ export interface MCPStdioServerConfig {
  * The server is accessed via HTTP at the given URL.
  */
 export interface MCPRemoteServerConfig {
-  /** The base URL of the remote MCP server (e.g., "http://localhost:3000", "https://api.example.com") */
-  url: string;
-  /** Transport type: 'http' (Streamable HTTP, default) or 'sse' (Server-Sent Events) */
-  type?: "http" | "sse";
   /** Optional HTTP headers to include in requests (e.g., authorization, custom headers) */
   headers?: Record<string, string>;
+  /** Transport type: 'http' (Streamable HTTP, default) or 'sse' (Server-Sent Events) */
+  type?: "http" | "sse";
+  /** The base URL of the remote MCP server (e.g., "http://localhost:3000", "https://api.example.com") */
+  url: string;
 }
 
 /**
@@ -63,8 +63,6 @@ export interface MCPManagerOptions {
  * Result of merging tools from multiple MCP servers.
  */
 export interface MCPToolMergeResult {
-  /** Merged set of tools from all connected servers */
-  tools: ToolSet;
   /** List of tool name conflicts detected during merge */
   conflicts: Array<{
     /** The conflicting tool name */
@@ -72,18 +70,20 @@ export interface MCPToolMergeResult {
     /** List of server names that provided this tool */
     sources: string[];
   }>;
+  /** Merged set of tools from all connected servers */
+  tools: ToolSet;
 }
 
 /**
  * Status information for a connected MCP server.
  */
 export interface MCPServerStatus {
+  /** Error message if status is "failed" (e.g., connection refused, timeout) */
+  error?: string;
   /** Name of the server (key in the MCP config) */
   name: string;
   /** Current connection state */
   status: "connected" | "failed" | "closed";
   /** Number of tools provided by this server */
   toolCount: number;
-  /** Error message if status is "failed" (e.g., connection refused, timeout) */
-  error?: string;
 }

--- a/packages/harness/src/token-utils.ts
+++ b/packages/harness/src/token-utils.ts
@@ -180,10 +180,12 @@ export function estimateToolSchemasTokens(tools: ToolSet): number {
     if (tool.description) {
       total += estimateTokens(tool.description);
     }
-    const schema =
-      "inputSchema" in tool
-        ? (tool as { inputSchema: unknown }).inputSchema
-        : undefined;
+    let schema: unknown;
+    if ("inputSchema" in tool) {
+      schema = (tool as { inputSchema: unknown }).inputSchema;
+    } else if ("parameters" in tool) {
+      schema = (tool as { parameters: unknown }).parameters;
+    }
     if (schema !== undefined) {
       let schemaJson: string | undefined;
       try {

--- a/packages/harness/src/token-utils.ts
+++ b/packages/harness/src/token-utils.ts
@@ -1,4 +1,4 @@
-import type { ModelMessage, TextPart } from "ai";
+import type { ModelMessage, TextPart, ToolSet } from "ai";
 
 // Constants for token estimation
 export const LATIN_CHARS_PER_TOKEN = 4;
@@ -166,4 +166,27 @@ export function estimateMessageTokens(message: ModelMessage): number {
   }
 
   return estimateTokens(extractMessageText(message));
+}
+
+export function estimateToolSchemasTokens(tools: ToolSet): number {
+  const entries = Object.entries(tools);
+  if (entries.length === 0) {
+    return 0;
+  }
+
+  let total = 0;
+  for (const [name, tool] of entries) {
+    total += estimateTokens(name);
+    if (tool.description) {
+      total += estimateTokens(tool.description);
+    }
+    const schema =
+      "inputSchema" in tool
+        ? (tool as { inputSchema: unknown }).inputSchema
+        : undefined;
+    if (schema) {
+      total += estimateTokens(JSON.stringify(schema));
+    }
+  }
+  return total;
 }

--- a/packages/harness/src/token-utils.ts
+++ b/packages/harness/src/token-utils.ts
@@ -185,7 +185,11 @@ export function estimateToolSchemasTokens(tools: ToolSet): number {
         ? (tool as { inputSchema: unknown }).inputSchema
         : undefined;
     if (schema) {
-      total += estimateTokens(JSON.stringify(schema));
+      try {
+        total += estimateTokens(JSON.stringify(schema));
+      } catch {
+        return total;
+      }
     }
   }
   return total;

--- a/packages/harness/src/token-utils.ts
+++ b/packages/harness/src/token-utils.ts
@@ -184,11 +184,15 @@ export function estimateToolSchemasTokens(tools: ToolSet): number {
       "inputSchema" in tool
         ? (tool as { inputSchema: unknown }).inputSchema
         : undefined;
-    if (schema) {
+    if (schema !== undefined) {
+      let schemaJson: string | undefined;
       try {
-        total += estimateTokens(JSON.stringify(schema));
+        schemaJson = JSON.stringify(schema);
       } catch {
-        return total;
+        schemaJson = undefined;
+      }
+      if (schemaJson !== undefined) {
+        total += estimateTokens(schemaJson);
       }
     }
   }

--- a/packages/harness/src/types.ts
+++ b/packages/harness/src/types.ts
@@ -38,7 +38,7 @@ export type AgentInstructions = string | (() => Promise<string>);
  * @example `mcp: mcpManager` — pre-initialized instance (lifecycle managed by caller)
  */
 export type MCPOption =
-  | boolean
+  | true
   | MCPServerConfig[]
   | {
       config?: boolean | string;

--- a/packages/harness/src/types.ts
+++ b/packages/harness/src/types.ts
@@ -11,6 +11,9 @@ import type {
   ToolSet,
 } from "ai";
 
+import type { MCPManager } from "./mcp-manager.js";
+import type { MCPServerConfig } from "./mcp-types.js";
+
 export type {
   LanguageModel,
   LanguageModelUsage,
@@ -25,17 +28,41 @@ type StreamTextOptions = Parameters<typeof streamText>[0];
 
 export type AgentInstructions = string | (() => Promise<string>);
 
+/**
+ * Options for configuring MCP (Model Context Protocol) client integration.
+ * Passed to {@link AgentConfig.mcp} to enable automatic MCP tool loading.
+ *
+ * @example `mcp: true` — load from .mcp.json
+ * @example `mcp: [{ url: "https://..." }]` — inline servers
+ * @example `mcp: { config: true, servers: [...] }` — both
+ * @example `mcp: mcpManager` — pre-initialized instance (lifecycle managed by caller)
+ */
+export type MCPOption =
+  | boolean
+  | MCPServerConfig[]
+  | {
+      config?: boolean | string;
+      onError?: (server: string, error: unknown) => void;
+      servers?: MCPServerConfig[];
+      toolsTimeout?: number;
+    }
+  | MCPManager;
+
 /** Configuration for creating an agent via {@link createAgent}. */
 export interface AgentConfig {
   experimental_repairToolCall?: StreamTextOptions["experimental_repairToolCall"];
   instructions?: AgentInstructions;
   maxStepsPerTurn?: number;
+  /** Optional MCP (Model Context Protocol) configuration. When provided, MCP tools are loaded and merged with local tools at agent creation time. */
+  mcp?: MCPOption;
   model: LanguageModel;
   tools?: ToolSet;
 }
 
 /** An agent instance returned by {@link createAgent}. */
 export interface Agent {
+  /** Release MCP connections and resources. Safe to call multiple times (idempotent). No-op if no MCP was configured. */
+  close(): Promise<void>;
   config: AgentConfig;
   stream(opts: AgentStreamOptions): AgentStreamResult;
 }

--- a/packages/minimal-agent/index.ts
+++ b/packages/minimal-agent/index.ts
@@ -1,4 +1,3 @@
-import { createAnthropic } from "@ai-sdk/anthropic";
 import {
   CheckpointHistory,
   type Command,
@@ -13,8 +12,13 @@ import {
   SessionManager,
   SessionMemoryTracker,
 } from "@ai-sdk-tool/harness";
+
 import { emitEvent, runHeadless } from "@ai-sdk-tool/headless";
 import { createAgentTUI } from "@ai-sdk-tool/tui";
+import {
+  createFriendli,
+  type FriendliAIProvider,
+} from "@friendliai/ai-provider";
 import type { LanguageModel } from "ai";
 import { defineCommand, runMain } from "citty";
 
@@ -27,7 +31,7 @@ import {
 } from "./compaction-config.js";
 import { env } from "./env.js";
 
-const DEFAULT_MODEL_ID = "claude-sonnet-4-6";
+const DEFAULT_MODEL_ID = "zai-org/GLM-5";
 const DEFAULT_SYSTEM_PROMPT = `You are a minimal example agent. Be concise and helpful.
 When the user shares personal information (name, preferences, pets, job, hobbies, etc.), remember it carefully.
 When asked to recall information, list ALL known facts — do not omit any details.`;
@@ -81,15 +85,16 @@ const LOCAL_COMMANDS: Command[] = [
   },
 ];
 
-function createAnthropicProvider() {
-  return createAnthropic({
-    apiKey: env.ANTHROPIC_API_KEY ?? "",
-    ...(env.ANTHROPIC_BASE_URL ? { baseURL: env.ANTHROPIC_BASE_URL } : {}),
+function createFriendliProvider(): FriendliAIProvider {
+  return createFriendli({
+    apiKey: env.FRIENDLI_TOKEN ?? "",
+    baseURL: env.FRIENDLI_BASE_URL || "serverless",
+    includeUsage: true,
   });
 }
 
 function resolveModelId(cliModel?: string): string {
-  return cliModel?.trim() || env.ANTHROPIC_MODEL || DEFAULT_MODEL_ID;
+  return cliModel?.trim() || env.FRIENDLI_MODEL || DEFAULT_MODEL_ID;
 }
 
 function createCompactionConfig(
@@ -139,13 +144,13 @@ function formatContextUsage(contextUsage: ContextUsage): string {
 const main = defineCommand({
   meta: {
     name: "minimal-agent",
-    description: "Minimal Anthropic-backed agent example",
+    description: "Minimal FriendliAI-backed agent example",
   },
   args: {
     model: {
       alias: ["m"],
       type: "string",
-      description: "Override the Anthropic model ID",
+      description: "Override the Friendli model ID",
     },
     prompt: {
       alias: ["p"],
@@ -155,111 +160,125 @@ const main = defineCommand({
     },
   },
   async run({ args }) {
-    const sessionManager = new SessionManager("minimal-agent");
-    sessionManager.initialize();
-    const circuitBreaker = new CompactionCircuitBreaker();
-    const sessionMemoryTracker = new SessionMemoryTracker();
-    const selectedModelId = resolveModelId(args.model);
-    const anthropic = createAnthropicProvider();
-    const model = anthropic(selectedModelId);
-    const compaction = createCompactionConfig(model, sessionMemoryTracker);
-    const messageHistory = new CheckpointHistory({
-      compaction,
-    });
-    messageHistory.setSystemPromptTokens(estimateTokens(DEFAULT_SYSTEM_PROMPT));
+    let agent: Awaited<ReturnType<typeof createAgent>> | undefined;
 
-    const agent = createAgent({
-      model,
-      instructions: DEFAULT_SYSTEM_PROMPT,
-    });
-    let lastProcessedMessageCount = 0;
+    let shouldExit = false;
 
-    const handleTurnComplete = (
-      messages: Array<{ message: { role: string; content: unknown } }>
-    ): void => {
-      const startFrom = Math.min(lastProcessedMessageCount, messages.length);
-      for (const { message } of messages.slice(startFrom)) {
-        if (message.role === "user" && typeof message.content === "string") {
-          sessionMemoryTracker.extractFactsFromUserMessage(message.content);
+    try {
+      const sessionManager = new SessionManager("minimal-agent");
+      sessionManager.initialize();
+      const circuitBreaker = new CompactionCircuitBreaker();
+      const sessionMemoryTracker = new SessionMemoryTracker();
+      const selectedModelId = resolveModelId(args.model);
+      const friendli = createFriendliProvider();
+      const model = friendli(selectedModelId);
+      const compaction = createCompactionConfig(model, sessionMemoryTracker);
+      const messageHistory = new CheckpointHistory({
+        compaction,
+      });
+      messageHistory.setSystemPromptTokens(
+        estimateTokens(DEFAULT_SYSTEM_PROMPT)
+      );
+
+      agent = await createAgent({
+        model,
+        instructions: DEFAULT_SYSTEM_PROMPT,
+        mcp: true,
+      });
+      let lastProcessedMessageCount = 0;
+
+      const handleTurnComplete = (
+        messages: Array<{ message: { role: string; content: unknown } }>
+      ): void => {
+        const startFrom = Math.min(lastProcessedMessageCount, messages.length);
+        for (const { message } of messages.slice(startFrom)) {
+          if (message.role === "user" && typeof message.content === "string") {
+            sessionMemoryTracker.extractFactsFromUserMessage(message.content);
+          }
         }
-      }
 
-      lastProcessedMessageCount = messages.length;
-    };
+        lastProcessedMessageCount = messages.length;
+      };
 
-    const handleCompactionComplete = (result: CompactionResult): void => {
-      if (!(result.success && result.summaryMessageId)) {
+      const handleCompactionComplete = (result: CompactionResult): void => {
+        if (!(result.success && result.summaryMessageId)) {
+          return;
+        }
+
+        const msg = messageHistory
+          .getAll()
+          .find((m) => m.id === result.summaryMessageId);
+        if (
+          msg?.message.role === "assistant" &&
+          typeof msg.message.content === "string"
+        ) {
+          sessionMemoryTracker.extractFactsFromSummary(msg.message.content);
+        }
+      };
+
+      const prompt = args.prompt?.trim();
+      if (prompt) {
+        await runHeadless({
+          agent,
+          circuitBreaker,
+          sessionId: sessionManager.getId(),
+          emitEvent,
+          initialUserMessage: {
+            content: prompt,
+          },
+          messageHistory,
+          maxIterations: 1,
+          modelId: selectedModelId,
+          compactionCallbacks: {
+            onCompactionComplete: handleCompactionComplete,
+          },
+          onTurnComplete: handleTurnComplete,
+        });
         return;
       }
 
-      const msg = messageHistory
-        .getAll()
-        .find((m) => m.id === result.summaryMessageId);
-      if (
-        msg?.message.role === "assistant" &&
-        typeof msg.message.content === "string"
-      ) {
-        sessionMemoryTracker.extractFactsFromSummary(msg.message.content);
-      }
-    };
-
-    const prompt = args.prompt?.trim();
-    if (prompt) {
-      await runHeadless({
+      await createAgentTUI({
         agent,
         circuitBreaker,
-        sessionId: sessionManager.getId(),
-        emitEvent,
-        initialUserMessage: {
-          content: prompt,
+        commands: LOCAL_COMMANDS,
+        footer: {
+          get text() {
+            const contextUsage = messageHistory.getContextUsage();
+            if (!contextUsage) {
+              return undefined;
+            }
+
+            return formatContextUsage(contextUsage);
+          },
         },
         messageHistory,
-        maxIterations: 1,
-        modelId: selectedModelId,
         compactionCallbacks: {
           onCompactionComplete: handleCompactionComplete,
         },
         onTurnComplete: handleTurnComplete,
+        header: {
+          title: "Minimal Agent",
+          get subtitle() {
+            return `${selectedModelId}\nSession: ${sessionManager.getId()}`;
+          },
+        },
+        onCommandAction: (action) => {
+          if (action.type === "new-session") {
+            sessionManager.initialize();
+            circuitBreaker.resetForNewSession();
+            sessionMemoryTracker.clear();
+            lastProcessedMessageCount = 0;
+          }
+        },
       });
-      return;
+      shouldExit = true;
+    } finally {
+      await agent?.close();
     }
 
-    await createAgentTUI({
-      agent,
-      circuitBreaker,
-      commands: LOCAL_COMMANDS,
-      footer: {
-        get text() {
-          const contextUsage = messageHistory.getContextUsage();
-          if (!contextUsage) {
-            return undefined;
-          }
-
-          return formatContextUsage(contextUsage);
-        },
-      },
-      messageHistory,
-      compactionCallbacks: {
-        onCompactionComplete: handleCompactionComplete,
-      },
-      onTurnComplete: handleTurnComplete,
-      header: {
-        title: "Minimal Agent",
-        get subtitle() {
-          return `${selectedModelId}\nSession: ${sessionManager.getId()}`;
-        },
-      },
-      onCommandAction: (action) => {
-        if (action.type === "new-session") {
-          sessionManager.initialize();
-          circuitBreaker.resetForNewSession();
-          sessionMemoryTracker.clear();
-          lastProcessedMessageCount = 0;
-        }
-      },
-    });
-
-    process.exit(0);
+    if (shouldExit) {
+      process.exit(0);
+    }
   },
 });
 

--- a/packages/minimal-agent/index.ts
+++ b/packages/minimal-agent/index.ts
@@ -1,3 +1,4 @@
+import { createAnthropic } from "@ai-sdk/anthropic";
 import {
   CheckpointHistory,
   type Command,
@@ -8,17 +9,13 @@ import {
   createAgent,
   createModelSummarizer,
   estimateTokens,
+  estimateToolSchemasTokens,
   getContextPressureLevel,
   SessionManager,
   SessionMemoryTracker,
 } from "@ai-sdk-tool/harness";
-
 import { emitEvent, runHeadless } from "@ai-sdk-tool/headless";
 import { createAgentTUI } from "@ai-sdk-tool/tui";
-import {
-  createFriendli,
-  type FriendliAIProvider,
-} from "@friendliai/ai-provider";
 import type { LanguageModel } from "ai";
 import { defineCommand, runMain } from "citty";
 
@@ -31,7 +28,7 @@ import {
 } from "./compaction-config.js";
 import { env } from "./env.js";
 
-const DEFAULT_MODEL_ID = "zai-org/GLM-5";
+const DEFAULT_MODEL_ID = "claude-sonnet-4-6";
 const DEFAULT_SYSTEM_PROMPT = `You are a minimal example agent. Be concise and helpful.
 When the user shares personal information (name, preferences, pets, job, hobbies, etc.), remember it carefully.
 When asked to recall information, list ALL known facts — do not omit any details.`;
@@ -85,16 +82,15 @@ const LOCAL_COMMANDS: Command[] = [
   },
 ];
 
-function createFriendliProvider(): FriendliAIProvider {
-  return createFriendli({
-    apiKey: env.FRIENDLI_TOKEN ?? "",
-    baseURL: env.FRIENDLI_BASE_URL || "serverless",
-    includeUsage: true,
+function createAnthropicProvider() {
+  return createAnthropic({
+    apiKey: env.ANTHROPIC_API_KEY ?? "",
+    ...(env.ANTHROPIC_BASE_URL ? { baseURL: env.ANTHROPIC_BASE_URL } : {}),
   });
 }
 
 function resolveModelId(cliModel?: string): string {
-  return cliModel?.trim() || env.FRIENDLI_MODEL || DEFAULT_MODEL_ID;
+  return cliModel?.trim() || env.ANTHROPIC_MODEL || DEFAULT_MODEL_ID;
 }
 
 function createCompactionConfig(
@@ -144,13 +140,13 @@ function formatContextUsage(contextUsage: ContextUsage): string {
 const main = defineCommand({
   meta: {
     name: "minimal-agent",
-    description: "Minimal FriendliAI-backed agent example",
+    description: "Minimal Anthropic-backed agent example",
   },
   args: {
     model: {
       alias: ["m"],
       type: "string",
-      description: "Override the Friendli model ID",
+      description: "Override the Anthropic model ID",
     },
     prompt: {
       alias: ["p"],
@@ -160,130 +156,121 @@ const main = defineCommand({
     },
   },
   async run({ args }) {
-    let agent: Awaited<ReturnType<typeof createAgent>> | undefined;
+    const sessionManager = new SessionManager("minimal-agent");
+    sessionManager.initialize();
+    const circuitBreaker = new CompactionCircuitBreaker();
+    const sessionMemoryTracker = new SessionMemoryTracker();
+    const selectedModelId = resolveModelId(args.model);
+    const anthropic = createAnthropicProvider();
+    const model = anthropic(selectedModelId);
+    const compaction = createCompactionConfig(model, sessionMemoryTracker);
+    const messageHistory = new CheckpointHistory({
+      compaction,
+    });
+    const agent = await createAgent({
+      model,
+      instructions: DEFAULT_SYSTEM_PROMPT,
+      mcp: [
+        {
+          command: "bunx",
+          args: ["--silent", "duckduckgo-mcp@latest"],
+        },
+      ],
+    });
 
-    let shouldExit = false;
+    messageHistory.setSystemPromptTokens(estimateTokens(DEFAULT_SYSTEM_PROMPT));
+    messageHistory.setToolSchemasTokens(
+      estimateToolSchemasTokens(agent.config.tools ?? {})
+    );
+    let lastProcessedMessageCount = 0;
 
-    try {
-      const sessionManager = new SessionManager("minimal-agent");
-      sessionManager.initialize();
-      const circuitBreaker = new CompactionCircuitBreaker();
-      const sessionMemoryTracker = new SessionMemoryTracker();
-      const selectedModelId = resolveModelId(args.model);
-      const friendli = createFriendliProvider();
-      const model = friendli(selectedModelId);
-      const compaction = createCompactionConfig(model, sessionMemoryTracker);
-      const messageHistory = new CheckpointHistory({
-        compaction,
-      });
-      messageHistory.setSystemPromptTokens(
-        estimateTokens(DEFAULT_SYSTEM_PROMPT)
-      );
-
-      agent = await createAgent({
-        model,
-        instructions: DEFAULT_SYSTEM_PROMPT,
-        mcp: [
-          {
-            command: "bunx",
-            args: ["--silent", "duckduckgo-mcp@latest"],
-          },
-        ],
-      });
-      let lastProcessedMessageCount = 0;
-
-      const handleTurnComplete = (
-        messages: Array<{ message: { role: string; content: unknown } }>
-      ): void => {
-        const startFrom = Math.min(lastProcessedMessageCount, messages.length);
-        for (const { message } of messages.slice(startFrom)) {
-          if (message.role === "user" && typeof message.content === "string") {
-            sessionMemoryTracker.extractFactsFromUserMessage(message.content);
-          }
+    const handleTurnComplete = (
+      messages: Array<{ message: { role: string; content: unknown } }>
+    ): void => {
+      const startFrom = Math.min(lastProcessedMessageCount, messages.length);
+      for (const { message } of messages.slice(startFrom)) {
+        if (message.role === "user" && typeof message.content === "string") {
+          sessionMemoryTracker.extractFactsFromUserMessage(message.content);
         }
+      }
 
-        lastProcessedMessageCount = messages.length;
-      };
+      lastProcessedMessageCount = messages.length;
+    };
 
-      const handleCompactionComplete = (result: CompactionResult): void => {
-        if (!(result.success && result.summaryMessageId)) {
-          return;
-        }
-
-        const msg = messageHistory
-          .getAll()
-          .find((m) => m.id === result.summaryMessageId);
-        if (
-          msg?.message.role === "assistant" &&
-          typeof msg.message.content === "string"
-        ) {
-          sessionMemoryTracker.extractFactsFromSummary(msg.message.content);
-        }
-      };
-
-      const prompt = args.prompt?.trim();
-      if (prompt) {
-        await runHeadless({
-          agent,
-          circuitBreaker,
-          sessionId: sessionManager.getId(),
-          emitEvent,
-          initialUserMessage: {
-            content: prompt,
-          },
-          messageHistory,
-          maxIterations: 1,
-          modelId: selectedModelId,
-          compactionCallbacks: {
-            onCompactionComplete: handleCompactionComplete,
-          },
-          onTurnComplete: handleTurnComplete,
-        });
+    const handleCompactionComplete = (result: CompactionResult): void => {
+      if (!(result.success && result.summaryMessageId)) {
         return;
       }
 
-      await createAgentTUI({
+      const msg = messageHistory
+        .getAll()
+        .find((m) => m.id === result.summaryMessageId);
+      if (
+        msg?.message.role === "assistant" &&
+        typeof msg.message.content === "string"
+      ) {
+        sessionMemoryTracker.extractFactsFromSummary(msg.message.content);
+      }
+    };
+
+    const prompt = args.prompt?.trim();
+    if (prompt) {
+      await runHeadless({
         agent,
         circuitBreaker,
-        commands: LOCAL_COMMANDS,
-        footer: {
-          get text() {
-            const contextUsage = messageHistory.getContextUsage();
-            if (!contextUsage) {
-              return undefined;
-            }
-
-            return formatContextUsage(contextUsage);
-          },
+        sessionId: sessionManager.getId(),
+        emitEvent,
+        initialUserMessage: {
+          content: prompt,
         },
         messageHistory,
+        maxIterations: 1,
+        modelId: selectedModelId,
         compactionCallbacks: {
           onCompactionComplete: handleCompactionComplete,
         },
         onTurnComplete: handleTurnComplete,
-        header: {
-          title: "Minimal Agent",
-          get subtitle() {
-            return `${selectedModelId}\nSession: ${sessionManager.getId()}`;
-          },
-        },
-        onCommandAction: (action) => {
-          if (action.type === "new-session") {
-            sessionManager.initialize();
-            circuitBreaker.resetForNewSession();
-            sessionMemoryTracker.clear();
-            lastProcessedMessageCount = 0;
-          }
-        },
       });
-      shouldExit = true;
-    } finally {
-      await agent?.close();
+      return;
     }
 
-    if (shouldExit) {
-      process.exit(0);
-    }
+    await createAgentTUI({
+      agent,
+      circuitBreaker,
+      commands: LOCAL_COMMANDS,
+      footer: {
+        get text() {
+          const contextUsage = messageHistory.getContextUsage();
+          if (!contextUsage) {
+            return undefined;
+          }
+
+          return formatContextUsage(contextUsage);
+        },
+      },
+      messageHistory,
+      compactionCallbacks: {
+        onCompactionComplete: handleCompactionComplete,
+      },
+      onTurnComplete: handleTurnComplete,
+      header: {
+        title: "Minimal Agent",
+        get subtitle() {
+          return `${selectedModelId}\nSession: ${sessionManager.getId()}`;
+        },
+      },
+      onCommandAction: (action) => {
+        if (action.type === "new-session") {
+          sessionManager.initialize();
+          circuitBreaker.resetForNewSession();
+          sessionMemoryTracker.clear();
+          lastProcessedMessageCount = 0;
+        }
+      },
+    });
+
+    await agent.close();
+    process.exit(0);
   },
 });
 

--- a/packages/minimal-agent/index.ts
+++ b/packages/minimal-agent/index.ts
@@ -214,63 +214,64 @@ const main = defineCommand({
     };
 
     const prompt = args.prompt?.trim();
-    if (prompt) {
-      await runHeadless({
+    try {
+      if (prompt) {
+        await runHeadless({
+          agent,
+          circuitBreaker,
+          sessionId: sessionManager.getId(),
+          emitEvent,
+          initialUserMessage: {
+            content: prompt,
+          },
+          messageHistory,
+          maxIterations: 1,
+          modelId: selectedModelId,
+          compactionCallbacks: {
+            onCompactionComplete: handleCompactionComplete,
+          },
+          onTurnComplete: handleTurnComplete,
+        });
+        return;
+      }
+
+      await createAgentTUI({
         agent,
         circuitBreaker,
-        sessionId: sessionManager.getId(),
-        emitEvent,
-        initialUserMessage: {
-          content: prompt,
+        commands: LOCAL_COMMANDS,
+        footer: {
+          get text() {
+            const contextUsage = messageHistory.getContextUsage();
+            if (!contextUsage) {
+              return undefined;
+            }
+
+            return formatContextUsage(contextUsage);
+          },
         },
         messageHistory,
-        maxIterations: 1,
-        modelId: selectedModelId,
         compactionCallbacks: {
           onCompactionComplete: handleCompactionComplete,
         },
         onTurnComplete: handleTurnComplete,
-      });
-      await agent.close();
-      return;
-    }
-
-    await createAgentTUI({
-      agent,
-      circuitBreaker,
-      commands: LOCAL_COMMANDS,
-      footer: {
-        get text() {
-          const contextUsage = messageHistory.getContextUsage();
-          if (!contextUsage) {
-            return undefined;
+        header: {
+          title: "Minimal Agent",
+          get subtitle() {
+            return `${selectedModelId}\nSession: ${sessionManager.getId()}`;
+          },
+        },
+        onCommandAction: (action) => {
+          if (action.type === "new-session") {
+            sessionManager.initialize();
+            circuitBreaker.resetForNewSession();
+            sessionMemoryTracker.clear();
+            lastProcessedMessageCount = 0;
           }
-
-          return formatContextUsage(contextUsage);
         },
-      },
-      messageHistory,
-      compactionCallbacks: {
-        onCompactionComplete: handleCompactionComplete,
-      },
-      onTurnComplete: handleTurnComplete,
-      header: {
-        title: "Minimal Agent",
-        get subtitle() {
-          return `${selectedModelId}\nSession: ${sessionManager.getId()}`;
-        },
-      },
-      onCommandAction: (action) => {
-        if (action.type === "new-session") {
-          sessionManager.initialize();
-          circuitBreaker.resetForNewSession();
-          sessionMemoryTracker.clear();
-          lastProcessedMessageCount = 0;
-        }
-      },
-    });
-
-    await agent.close();
+      });
+    } finally {
+      await agent.close();
+    }
     process.exit(0);
   },
 });

--- a/packages/minimal-agent/index.ts
+++ b/packages/minimal-agent/index.ts
@@ -183,7 +183,12 @@ const main = defineCommand({
       agent = await createAgent({
         model,
         instructions: DEFAULT_SYSTEM_PROMPT,
-        mcp: true,
+        mcp: [
+          {
+            command: "bunx",
+            args: ["--silent", "duckduckgo-mcp@latest"],
+          },
+        ],
       });
       let lastProcessedMessageCount = 0;
 

--- a/packages/minimal-agent/index.ts
+++ b/packages/minimal-agent/index.ts
@@ -172,8 +172,8 @@ const main = defineCommand({
       instructions: DEFAULT_SYSTEM_PROMPT,
       mcp: [
         {
-          command: "bunx",
-          args: ["--silent", "duckduckgo-mcp@latest"],
+          command: "npx",
+          args: ["-y", "duckduckgo-mcp@latest"],
         },
       ],
     });

--- a/packages/minimal-agent/index.ts
+++ b/packages/minimal-agent/index.ts
@@ -231,6 +231,7 @@ const main = defineCommand({
         },
         onTurnComplete: handleTurnComplete,
       });
+      await agent.close();
       return;
     }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -105,6 +105,9 @@ importers:
 
   packages/harness:
     dependencies:
+      '@ai-sdk/mcp':
+        specifier: ^1.0.32
+        version: 1.0.32(zod@4.3.6)
       '@ai-sdk/provider':
         specifier: ^3.0.8
         version: 3.0.8
@@ -224,6 +227,12 @@ packages:
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
 
+  '@ai-sdk/mcp@1.0.32':
+    resolution: {integrity: sha512-WkZquZ+bPAwG1mH9yrjGVPKLycaxnUQhJkkYAAZTSAuIgENcO4k/V38+rI28AneoE995mpWn40sFiZ96fHTPgw==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
   '@ai-sdk/openai-compatible@2.0.35':
     resolution: {integrity: sha512-g3wA57IAQFb+3j4YuFndgkUdXyRETZVvbfAWM+UX7bZSxA3xjes0v3XKgIdKdekPtDGsh4ZX2byHD0gJIMPfiA==}
     engines: {node: '>=18'}
@@ -244,6 +253,12 @@ packages:
 
   '@ai-sdk/provider-utils@4.0.19':
     resolution: {integrity: sha512-3eG55CrSWCu2SXlqq2QCsFjo3+E7+Gmg7i/oRVoSZzIodTuDSfLb3MRje67xE9RFea73Zao7Lm4mADIfUETKGg==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
+  '@ai-sdk/provider-utils@4.0.22':
+    resolution: {integrity: sha512-B2OTFcRw/Pdka9ZTjpXv6T6qZ6RruRuLokyb8HwW+aoW9ndJ3YasA3/mVswyJw7VMBF8ofXgqvcrCt9KYvFifg==}
     engines: {node: '>=18'}
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
@@ -1140,6 +1155,10 @@ packages:
     resolution: {integrity: sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==}
     engines: {node: '>=6'}
 
+  pkce-challenge@5.0.1:
+    resolution: {integrity: sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==}
+    engines: {node: '>=16.20.0'}
+
   postcss@8.5.8:
     resolution: {integrity: sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==}
     engines: {node: ^10 || ^12 || >=14}
@@ -1433,6 +1452,13 @@ snapshots:
       '@vercel/oidc': 3.1.0
       zod: 4.3.6
 
+  '@ai-sdk/mcp@1.0.32(zod@4.3.6)':
+    dependencies:
+      '@ai-sdk/provider': 3.0.8
+      '@ai-sdk/provider-utils': 4.0.22(zod@4.3.6)
+      pkce-challenge: 5.0.1
+      zod: 4.3.6
+
   '@ai-sdk/openai-compatible@2.0.35(zod@4.3.6)':
     dependencies:
       '@ai-sdk/provider': 3.0.8
@@ -1453,6 +1479,13 @@ snapshots:
       zod: 4.3.6
 
   '@ai-sdk/provider-utils@4.0.19(zod@4.3.6)':
+    dependencies:
+      '@ai-sdk/provider': 3.0.8
+      '@standard-schema/spec': 1.1.0
+      eventsource-parser: 3.0.6
+      zod: 4.3.6
+
+  '@ai-sdk/provider-utils@4.0.22(zod@4.3.6)':
     dependencies:
       '@ai-sdk/provider': 3.0.8
       '@standard-schema/spec': 1.1.0
@@ -2235,6 +2268,8 @@ snapshots:
   picomatch@4.0.4: {}
 
   pify@4.0.1: {}
+
+  pkce-challenge@5.0.1: {}
 
   postcss@8.5.8:
     dependencies:


### PR DESCRIPTION
## Summary
- Add MCP (Model Context Protocol) client support to `@ai-sdk-tool/harness` so any consumer agent can connect to MCP servers and use their tools alongside local tools
- Uses `@ai-sdk/mcp` (Vercel official) for seamless AI SDK integration
- CEA automatically loads MCP tools from `.mcp.json` on startup

## What's New

### New Modules (`@ai-sdk-tool/harness`)
- **`MCPManager`** — MCP server lifecycle orchestrator (connect, tools, close)
- **`loadMCPConfig`** — `.mcp.json` parser with Zod validation (stdio/HTTP/SSE)
- **`mergeMCPTools`** — conflict-aware tool merger (local↔MCP, MCP↔MCP)
- **Type definitions** — `MCPServerConfig`, `MCPManagerOptions`, `MCPServerStatus`, etc.

### Key Features
- **Three transports**: stdio, Streamable HTTP, SSE
- **Graceful degradation**: failed MCP servers are warned and skipped
- **Conflict-aware**: tool name collisions get `servername_` prefix automatically
- **Parallel init**: all MCP servers connect via `Promise.allSettled()`
- **Timeout protection**: 30s default for `client.tools()` calls
- **Idempotent cleanup**: `MCPManager.close()` safe to call multiple times
- **Zero regression**: no `.mcp.json` = identical behavior to before

### CEA Integration
- MCPManager initialized after `initializeTools()` in `main.ts`
- MCP tools merged via `mergeMCPTools()` for conflict-aware local↔MCP merging
- Cleanup wired into `exitWithCleanup()` and `process.once("exit")`

## Usage

Create `.mcp.json` in the project root:
```json
{
  "mcpServers": {
    "my-server": {
      "command": "npx",
      "args": ["-y", "@scope/mcp-server"],
      "env": { "API_KEY": "..." }
    },
    "remote-server": {
      "url": "https://api.example.com/mcp",
      "type": "http"
    }
  }
}
```

## Verification
- 548 vitest tests pass (34 test files)
- Full typecheck + build pass across all 5 packages
- Final verification wave: 4 parallel reviewers all APPROVE

## Files Changed
| File | Description |
|------|-------------|
| `harness/src/mcp-types.ts` | Type definitions (87 lines) |
| `harness/src/mcp-config.ts` | Config parser + Zod schemas (98 lines) |
| `harness/src/mcp-config.test.ts` | Config parser tests (221 lines) |
| `harness/src/mcp-tool-merger.ts` | Conflict-aware merger (77 lines) |
| `harness/src/mcp-tool-merger.test.ts` | Merger tests (186 lines) |
| `harness/src/mcp-manager.ts` | MCPManager class (203 lines) |
| `harness/src/mcp-manager.test.ts` | Manager tests (388 lines) |
| `harness/src/index.ts` | Public API exports (+14 lines) |
| `harness/package.json` | `@ai-sdk/mcp` dependency |
| `cea/src/entrypoints/main.ts` | CEA integration (+36 lines) |

## Future Work (Out of Scope)
- MCP Resources support
- MCP Prompts support  
- Global config file (`~/.config/plugsuits/mcp.json`)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds MCP client support to `@ai-sdk-tool/harness`, makes `createAgent` async with an `mcp` option and `Agent.close()`, and integrates MCP tools into CEA and the minimal agent. Context budgeting now includes tool schema tokens, and MCP cache keys use absolute config paths to prevent cross-CWD collisions.

- **New Features**
  - MCP: `MCPManager` with stdio/HTTP/SSE via `@ai-sdk/mcp`, per-server `toolsByServer()`/`status()`, parallel connect and tool fetch (30s default), and connection caching with ref counts. Includes `.mcp.json` loader (`loadMCPConfig`), conflict-aware merger (`mergeMCPTools`), helpers (`isRemoteConfig`, `isStdioConfig`, `sanitizeServerName`), and types.
  - `createAgent({ mcp })`: async, loads MCP tools from `.mcp.json`, inline servers, or a provided `MCPManager`; returns `Agent.close()` for cleanup. Colliding MCP tools are auto-prefixed (numeric suffix when needed).
  - CEA/minimal agent: merge MCP tools with conflicts logged, update token budgets with `estimateToolSchemasTokens` (supports `inputSchema` and `parameters`), and close MCP on exit. Minimal agent adds DuckDuckGo search via MCP.

- **Bug Fixes**
  - Lifecycle: share a single `init()` across callers; close clients if closed during init and after async tool fetch; skip `.mcp.json` for inline-only; preserve file servers when combining config+inline; wrap MCP close in `exitWithCleanup()` with a 1s timeout and `.catch()`; await `exitWithCleanup` on headless errors; minimal agent calls `agent.close()` in a `finally`.
  - Caching: include `toolsTimeout` in the cache key and exclude `onError`; scope the default `.mcp.json` cache key by `process.cwd()`; preserve inline server array order in cache keys; use an absolute config path in combined cache keys to avoid cross-CWD collisions.
  - Tool merge: prevent alias overwrites by reserving keys; ensure numeric suffixes are added reliably; non-conflict MCP tools are aliased instead of dropped when an alias collides.
  - Token estimation/budgeting: `estimateToolSchemasTokens()` skips only non-serializable schemas and supports `parameters`; system+tool schema tokens are included in compaction acceptance checks; tokensBefore now includes the same overhead as tokensAfter for consistent effectiveness decisions.
  - Config validation: reject empty stdio `command` strings in `.mcp.json`.

<sup>Written for commit c9d9b027444b31191f4846bdd78ff895e2fc757e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

