### PR TITLE
fix(headless): remove "(no text output)" fallback in stream processor

### DIFF
--- a/.changeset/fix-no-text-output-fallback.md
+++ b/.changeset/fix-no-text-output-fallback.md
@@ -1,0 +1,5 @@
+---
+"@ai-sdk-tool/headless": patch
+---
+
+Remove "(no text output)" fallback from agent step events in stream processor. Tool-call-only steps now emit an empty string instead of the placeholder, preventing downstream consumers from concatenating the literal into final responses.

--- a/packages/headless/src/stream-processor.ts
+++ b/packages/headless/src/stream-processor.ts
@@ -9,7 +9,7 @@ import type {
 } from "./types";
 
 export const extractToolOutput = (
-  output: unknown,
+  output: unknown
 ): { stdout: string; error?: string; exitCode?: number } => {
   if (typeof output === "object" && output !== null && "output" in output) {
     const result = output as {
@@ -63,7 +63,7 @@ export const handleToolInputStart = (
   part: {
     id?: string;
     toolCallId?: string;
-  },
+  }
 ): void => {
   const id = getToolInputId(part);
   if (!id) {
@@ -83,7 +83,7 @@ export const handleToolInputDelta = (
     id?: string;
     inputTextDelta?: unknown;
     toolCallId?: string;
-  },
+  }
 ): void => {
   const toolCallId = getToolInputId(part);
   const toolCallDelta = getToolInputChunk(part);
@@ -110,7 +110,7 @@ export const upsertCompletedToolCall = (
     input?: unknown;
     toolCallId: string;
     toolName: string;
-  },
+  }
 ): void => {
   const existing = pendingToolCalls.get(part.toolCallId);
   if (existing) {
@@ -129,7 +129,7 @@ export const upsertCompletedToolCall = (
 
 export const bufferedToolCallData = (
   pendingToolCalls: Map<string, PendingToolCall>,
-  completedToolCallIds: Set<string>,
+  completedToolCallIds: Set<string>
 ): ToolCallData[] | undefined => {
   const result: ToolCallData[] = [];
   for (const [id, pending] of pendingToolCalls) {
@@ -149,7 +149,7 @@ export const bufferedToolCallData = (
 };
 
 const parseToolArguments = (
-  argumentsStr: string,
+  argumentsStr: string
 ): Record<string, unknown> | null => {
   try {
     return JSON.parse(argumentsStr) as Record<string, unknown>;
@@ -161,7 +161,7 @@ const parseToolArguments = (
 export const emitMalformedToolCallErrors = (
   emitEvent: (event: TrajectoryEvent) => void,
   completedToolCallIds: Set<string>,
-  pendingToolCalls: Map<string, PendingToolCall>,
+  pendingToolCalls: Map<string, PendingToolCall>
 ): void => {
   for (const [id, pending] of pendingToolCalls) {
     if (completedToolCallIds.has(id)) {
@@ -180,7 +180,7 @@ export const emitMalformedToolCallsSummary = (
   emitEvent: (event: TrajectoryEvent) => void,
   completedToolCallIds: Set<string>,
   lastFinishReason: string | undefined,
-  pendingToolCalls: Map<string, PendingToolCall>,
+  pendingToolCalls: Map<string, PendingToolCall>
 ): void => {
   if (
     lastFinishReason !== "tool-calls" ||
@@ -221,7 +221,7 @@ export interface ProcessStreamResult {
 const STREAM_RESPONSE_TIMEOUT_MS = 30_000;
 
 export const processStream = async (
-  opts: ProcessStreamOptions,
+  opts: ProcessStreamOptions
 ): Promise<ProcessStreamResult> => {
   const { stream, stepId, modelId, emitEvent, shouldContinue, onMessages } =
     opts;
@@ -299,13 +299,13 @@ export const processStream = async (
   emitMalformedToolCallErrors(
     emitEvent,
     completedToolCallIds,
-    pendingToolCalls,
+    pendingToolCalls
   );
   emitMalformedToolCallsSummary(
     emitEvent,
     completedToolCallIds,
     lastFinishReason,
-    pendingToolCalls,
+    pendingToolCalls
   );
 
   try {
@@ -314,12 +314,12 @@ export const processStream = async (
       Promise.all([stream.response, stream.finishReason, stream.usage]).finally(
         () => {
           clearTimeout(timeoutId);
-        },
+        }
       ),
       new Promise<never>((_, reject) => {
         timeoutId = setTimeout(
           () => reject(new Error("Stream response timeout")),
-          STREAM_RESPONSE_TIMEOUT_MS,
+          STREAM_RESPONSE_TIMEOUT_MS
         );
       }),
     ]);

--- a/packages/headless/src/stream-processor.ts
+++ b/packages/headless/src/stream-processor.ts
@@ -9,7 +9,7 @@ import type {
 } from "./types";
 
 export const extractToolOutput = (
-  output: unknown
+  output: unknown,
 ): { stdout: string; error?: string; exitCode?: number } => {
   if (typeof output === "object" && output !== null && "output" in output) {
     const result = output as {
@@ -63,7 +63,7 @@ export const handleToolInputStart = (
   part: {
     id?: string;
     toolCallId?: string;
-  }
+  },
 ): void => {
   const id = getToolInputId(part);
   if (!id) {
@@ -83,7 +83,7 @@ export const handleToolInputDelta = (
     id?: string;
     inputTextDelta?: unknown;
     toolCallId?: string;
-  }
+  },
 ): void => {
   const toolCallId = getToolInputId(part);
   const toolCallDelta = getToolInputChunk(part);
@@ -110,7 +110,7 @@ export const upsertCompletedToolCall = (
     input?: unknown;
     toolCallId: string;
     toolName: string;
-  }
+  },
 ): void => {
   const existing = pendingToolCalls.get(part.toolCallId);
   if (existing) {
@@ -129,7 +129,7 @@ export const upsertCompletedToolCall = (
 
 export const bufferedToolCallData = (
   pendingToolCalls: Map<string, PendingToolCall>,
-  completedToolCallIds: Set<string>
+  completedToolCallIds: Set<string>,
 ): ToolCallData[] | undefined => {
   const result: ToolCallData[] = [];
   for (const [id, pending] of pendingToolCalls) {
@@ -149,7 +149,7 @@ export const bufferedToolCallData = (
 };
 
 const parseToolArguments = (
-  argumentsStr: string
+  argumentsStr: string,
 ): Record<string, unknown> | null => {
   try {
     return JSON.parse(argumentsStr) as Record<string, unknown>;
@@ -161,7 +161,7 @@ const parseToolArguments = (
 export const emitMalformedToolCallErrors = (
   emitEvent: (event: TrajectoryEvent) => void,
   completedToolCallIds: Set<string>,
-  pendingToolCalls: Map<string, PendingToolCall>
+  pendingToolCalls: Map<string, PendingToolCall>,
 ): void => {
   for (const [id, pending] of pendingToolCalls) {
     if (completedToolCallIds.has(id)) {
@@ -180,7 +180,7 @@ export const emitMalformedToolCallsSummary = (
   emitEvent: (event: TrajectoryEvent) => void,
   completedToolCallIds: Set<string>,
   lastFinishReason: string | undefined,
-  pendingToolCalls: Map<string, PendingToolCall>
+  pendingToolCalls: Map<string, PendingToolCall>,
 ): void => {
   if (
     lastFinishReason !== "tool-calls" ||
@@ -221,7 +221,7 @@ export interface ProcessStreamResult {
 const STREAM_RESPONSE_TIMEOUT_MS = 30_000;
 
 export const processStream = async (
-  opts: ProcessStreamOptions
+  opts: ProcessStreamOptions,
 ): Promise<ProcessStreamResult> => {
   const { stream, stepId, modelId, emitEvent, shouldContinue, onMessages } =
     opts;
@@ -299,13 +299,13 @@ export const processStream = async (
   emitMalformedToolCallErrors(
     emitEvent,
     completedToolCallIds,
-    pendingToolCalls
+    pendingToolCalls,
   );
   emitMalformedToolCallsSummary(
     emitEvent,
     completedToolCallIds,
     lastFinishReason,
-    pendingToolCalls
+    pendingToolCalls,
   );
 
   try {
@@ -314,12 +314,12 @@ export const processStream = async (
       Promise.all([stream.response, stream.finishReason, stream.usage]).finally(
         () => {
           clearTimeout(timeoutId);
-        }
+        },
       ),
       new Promise<never>((_, reject) => {
         timeoutId = setTimeout(
           () => reject(new Error("Stream response timeout")),
-          STREAM_RESPONSE_TIMEOUT_MS
+          STREAM_RESPONSE_TIMEOUT_MS,
         );
       }),
     ]);
@@ -330,7 +330,7 @@ export const processStream = async (
       step_id: stepId,
       timestamp: new Date().toISOString(),
       source: "agent",
-      message: currentText || "(no text output)",
+      message: currentText,
       model_name: modelId,
       reasoning_content: currentReasoning || undefined,
       tool_calls: bufferedToolCallData(pendingToolCalls, completedToolCallIds),


### PR DESCRIPTION
## Summary

- Remove the `"(no text output)"` fallback string from `processStream()` in `@ai-sdk-tool/headless`
- When the LLM produces a tool-call-only step (no text), the agent step event now emits an empty string instead of the literal placeholder

## Problem

Downstream consumers (e.g. clawroid's `atif-event-adapter` → `operation-builder`) concatenate all step messages into the final delivery text. When a multi-step response includes a tool-call step with no text, the fallback `"(no text output)"` gets prepended to the actual response:

```
"(no text output)아이폰 15입니다."
```

instead of just:

```
"아이폰 15입니다."
```

## Fix

`stream-processor.ts` line 333:
```diff
- message: currentText || "(no text output)",
+ message: currentText,
```

All 23 existing tests pass. No downstream code depends on this specific fallback string.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the "(no text output)" fallback in `processStream()` within `@ai-sdk-tool/headless`. Tool-call-only agent steps now emit an empty string, preventing the placeholder from being concatenated into final outputs; includes a changeset for a patch release.

<sup>Written for commit 4ada7d69433a266e0f097b607497f5d9ea4dd1d0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

