### PR TITLE
chore(tgbot): mark package as private

### DIFF
--- a/packages/tgbot/package.json
+++ b/packages/tgbot/package.json
@@ -1,20 +1,9 @@
 {
   "name": "@plugsuits/tgbot",
   "version": "0.1.1",
+  "private": true,
   "description": "Telegram bot powered by Chat SDK + @ai-sdk-tool/harness",
   "type": "module",
-  "main": "dist/main.js",
-  "types": "./dist/main.d.ts",
-  "exports": {
-    ".": {
-      "@ai-sdk-tool/source": "./src/main.ts",
-      "types": "./dist/main.d.ts",
-      "import": "./dist/main.js"
-    }
-  },
-  "files": [
-    "dist"
-  ],
   "scripts": {
     "dev": "node --watch --env-file=.env --conditions=@ai-sdk-tool/source --import tsx src/main.ts",
     "build": "tsc && node ../../scripts/fix-esm-imports.mjs dist",


### PR DESCRIPTION
## Summary

- Mark `@plugsuits/tgbot` as `"private": true` so it is never published to npm
- Remove publish-related fields (`main`, `types`, `exports`, `files`) that are unnecessary for a private package

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Mark `@plugsuits/tgbot` as private to prevent accidental npm publishes. Removed publish-related fields (`main`, `types`, `exports`, `files`) since they are unnecessary for a private package.

<sup>Written for commit c7bbf7450dddcfbae4e42428bb729f16207bdf99. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

