### PR TITLE
fix(tui): keep prompt gap stable when spinner toggles

### DIFF
--- a/.changeset/stable-prompt-gap.md
+++ b/.changeset/stable-prompt-gap.md
@@ -1,0 +1,5 @@
+---
+"@ai-sdk-tool/tui": patch
+---
+
+Reserve a fixed two-line slot above the prompt editor so the foreground spinner no longer causes layout shift when it mounts or unmounts, and drop the redundant header bottom spacer that duplicated that gap.

--- a/packages/tui/src/agent-tui.ts
+++ b/packages/tui/src/agent-tui.ts
@@ -161,6 +161,22 @@ class StatusSpinner extends Text {
   }
 }
 
+/**
+ * Fixed-height placeholder that occupies the same 2 vertical lines as
+ * {@link StatusSpinner} while idle. Keeping the status slot at a constant
+ * height prevents layout shift when the spinner is mounted/unmounted, and
+ * guarantees a persistent blank buffer directly above the prompt editor.
+ */
+class IdleStatusPlaceholder extends Text {
+  constructor() {
+    super("", 1, 0);
+  }
+
+  render(_width: number): string[] {
+    return ["", ""];
+  }
+}
+
 const truncatePlainToWidth = (text: string, maxWidth: number): string => {
   if (maxWidth <= 0) {
     return "";
@@ -708,7 +724,6 @@ export async function createAgentTUI(config: AgentTUIConfig): Promise<void> {
   headerContainer.addChild(new Spacer(1));
   headerContainer.addChild(title);
   headerContainer.addChild(help);
-  headerContainer.addChild(new Spacer(1));
 
   const editor = new Editor(tui, editorTheme, {
     paddingX: 1,
@@ -781,13 +796,15 @@ export async function createAgentTUI(config: AgentTUIConfig): Promise<void> {
       message
     );
 
+  const idleStatusPlaceholder = new IdleStatusPlaceholder();
+
   const renderForegroundStatus = (): void => {
     statusContainer.clear();
-    if (foregroundStatus) {
-      statusContainer.addChild(foregroundStatus);
-    }
+    statusContainer.addChild(foregroundStatus ?? idleStatusPlaceholder);
     tui.requestRender();
   };
+
+  renderForegroundStatus();
 
   const renderFooterStatuses = (): void => {
     footerStatusBar.setEntries([...backgroundStatuses.values()]);


### PR DESCRIPTION
## Summary
- Introduce \`IdleStatusPlaceholder\` so the status slot above the prompt editor always occupies the same 2 vertical lines as \`StatusSpinner\`, eliminating the layout shift that previously happened whenever the foreground spinner mounted/unmounted.
- Seed the status slot with the placeholder on startup via an initial \`renderForegroundStatus()\` call so the invariant holds from the very first frame.
- Remove the redundant \`Spacer(1)\` at the bottom of \`headerContainer\` — the always-on status slot already provides separation between the header and the prompt.

## Behavior
| State | \`statusContainer\` height | Gap above prompt |
|---|---|---|
| Idle | 2 lines (\`IdleStatusPlaceholder\` returns \`["", ""]\`) | 2 blank lines |
| Streaming | 2 lines (\`StatusSpinner\` returns \`["", spinner_text]\`) | 1 blank + spinner |

The fix lives entirely in \`packages/tui/src/agent-tui.ts\` (\`createAgentTUI\`), so every TUI consumer (\`@ai-sdk-tool/cea\`, \`@plugsuits/minimal-agent\`) picks it up automatically.

## Verification
- \`pnpm -F @ai-sdk-tool/tui typecheck\` passes.
- \`pnpm run typecheck\` across the monorepo passes.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Keep the prompt gap stable by reserving a fixed two-line status slot above the editor, so the spinner toggling no longer shifts the layout.

- **Bug Fixes**
  - Added `IdleStatusPlaceholder` with the same height as `StatusSpinner`, keeping `statusContainer` at 2 lines.
  - Seeded the placeholder on startup via an initial `renderForegroundStatus()` call.
  - Removed the redundant `Spacer(1)` under the header; the status slot now provides the separation.

<sup>Written for commit dab2b649067e182960d0dd62b63c73f56f1038ec. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

