### PR TITLE
feat(harness): FileSnapshotStore takes top-level dir, auto-gitignore

### DIFF
--- a/.changeset/file-snapshot-store-top-level-dir.md
+++ b/.changeset/file-snapshot-store-top-level-dir.md
@@ -1,0 +1,19 @@
+---
+"@ai-sdk-tool/harness": patch
+"@plugsuits/minimal-agent": patch
+"@plugsuits/tgbot": patch
+"plugsuits": patch
+---
+
+`FileSnapshotStore` now takes a top-level directory (e.g. `.plugsuits`, `.minimal-agent`) and manages its internal layout itself: session snapshots land in `<root>/sessions/*.jsonl`. The public `rootDir` / `sessionsDir` getters expose the resolved paths for consumers that want to co-locate related files (e.g. session memory).
+
+When the root directory lives inside a git worktree (detected by a sibling `.git` marker, directory or file), the store appends the top-level directory to that worktree's `.gitignore` if not already listed. The update is concurrency-safe: an exclusive `.gitignore.lock` (via `openSync(path, "wx")`) serializes writers, and the content swap is atomic (temp-file + rename). Stale locks older than 30s are reclaimed so a crashed writer can't wedge the next caller. The file's existing line-ending convention is preserved (LF or CRLF), and the helper refuses to write to any ancestor `.gitignore` that is not at a verified worktree root — so it cannot accidentally modify a parent repo's or a user's home-level ignore file. Disable with `new FileSnapshotStore(dir, { autoGitignore: false })`.
+
+Env var migrations (no backward compatibility):
+
+- `minimal-agent`: `SESSION_DIR` → `MINIMAL_AGENT_DIR` (default `.minimal-agent`)
+- `tgbot`: `SESSION_DIR` → `TGBOT_DIR` (default `<tmpdir>/tgbot`)
+
+CEA now constructs its store with `.plugsuits` as the top-level directory and derives its session-memory path from `store.sessionsDir`.
+
+The previously-undocumented `getFilePath` fallback for unencoded session filenames has been removed; session files always live at `<sessionsDir>/<encodeSessionId(sessionId)>.jsonl`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -120,7 +120,17 @@ const history = new CheckpointHistory({ compaction: {...} });
 
 // 2. File-persisted (recommended for most consumers)
 import { FileSnapshotStore } from "@ai-sdk-tool/harness/sessions";
-const store = new FileSnapshotStore(".plugsuits/sessions");
+// Pass a top-level directory (e.g. ".plugsuits", ".minimal-agent").
+// The store manages its internal layout: <root>/sessions/*.jsonl
+// Auto-gitignore: when the root dir lives inside a git worktree (detected by
+// a sibling `.git` marker, dir or file), the store appends the top-level dir
+// to that worktree's `.gitignore` if not already listed. The update is atomic
+// (lockfile + temp-file rename) and preserves LF/CRLF line endings. It
+// refuses to modify any ancestor `.gitignore` that is not at a verified
+// worktree root. Disable with `{ autoGitignore: false }`.
+const store = new FileSnapshotStore(".plugsuits");
+// store.sessionsDir is resolved, e.g. "<cwd>/.plugsuits/sessions"
+// (use for co-located files).
 const history = await CheckpointHistory.fromSnapshot(store, sessionId, { compaction });
 // After each turn — caller decides when:
 await store.save(sessionId, history.snapshot());

--- a/packages/cea/src/entrypoints/main.ts
+++ b/packages/cea/src/entrypoints/main.ts
@@ -1,4 +1,4 @@
-import { mkdirSync, readFileSync } from "node:fs";
+import { readFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import {
@@ -142,16 +142,14 @@ if (!sessionManagerScope.__ceaSessionManager) {
   sessionManagerScope.__ceaSessionManager = new SessionManager();
 }
 const sessionManager = sessionManagerScope.__ceaSessionManager;
-const sessionStoreBaseDir = join(process.cwd(), ".plugsuits", "sessions");
-mkdirSync(sessionStoreBaseDir, { recursive: true });
-const store = new FileSnapshotStore(sessionStoreBaseDir);
+const store = new FileSnapshotStore(join(process.cwd(), ".plugsuits"));
 const userPreferencesBundle = createUserPreferencesStore();
 configurePreferencesPersistence({
   bundle: userPreferencesBundle.bundle,
   workspaceStore: userPreferencesBundle.workspaceStore,
 });
 const resolveSessionMemoryStorePath = (sessionId: string): string =>
-  join(sessionStoreBaseDir, sessionId, "session-memory.md");
+  join(store.sessionsDir, sessionId, "session-memory.md");
 const createSessionMemoryStore = (sessionId: string): FileMemoryStore =>
   new FileMemoryStore(resolveSessionMemoryStorePath(sessionId));
 let messageHistory: CheckpointHistory;

--- a/packages/harness/README.md
+++ b/packages/harness/README.md
@@ -38,7 +38,7 @@ const assistant = defineAgent({
 const runtime = await createAgentRuntime({
   name: "my-assistant",
   agents: [assistant],
-  persistence: { snapshotStore: new FileSnapshotStore(".sessions") },
+  persistence: { snapshotStore: new FileSnapshotStore(".my-assistant") },
 });
 
 const session = await runtime.openSession();

--- a/packages/harness/src/file-snapshot-store.test.ts
+++ b/packages/harness/src/file-snapshot-store.test.ts
@@ -1,4 +1,13 @@
-import { appendFileSync, mkdtempSync, rmSync } from "node:fs";
+import {
+  appendFileSync,
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  realpathSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
@@ -11,7 +20,7 @@ describe("FileSnapshotStore", () => {
 
   beforeEach(() => {
     tmpDir = mkdtempSync(join(tmpdir(), "file-snapshot-store-test-"));
-    store = new FileSnapshotStore(tmpDir);
+    store = new FileSnapshotStore(tmpDir, { autoGitignore: false });
   });
 
   afterEach(() => {
@@ -180,9 +189,9 @@ describe("FileSnapshotStore", () => {
     });
   });
 
-  it("loads existing legacy JSONL sessions", async () => {
-    const sessionId = "legacy_session";
-    const filePath = join(tmpDir, `${sessionId}.jsonl`);
+  it("loads existing JSONL sessions written in legacy line formats", async () => {
+    const sessionId = "legacy-session";
+    const filePath = join(tmpDir, "sessions", `${sessionId}.jsonl`);
 
     appendFileSync(
       filePath,
@@ -221,6 +230,98 @@ describe("FileSnapshotStore", () => {
       toolSchemasTokens: 0,
       compactionState: { summaryMessageId: "legacy-msg" },
     });
+  });
+
+  it("exposes rootDir and sessionsDir paths", () => {
+    expect(store.rootDir).toBe(tmpDir);
+    expect(store.sessionsDir).toBe(join(tmpDir, "sessions"));
+    expect(existsSync(store.sessionsDir)).toBe(true);
+  });
+
+  it("resolves relative root dirs at construction time", async () => {
+    const originalCwd = process.cwd();
+    const worktree = realpathSync(
+      mkdtempSync(join(tmpdir(), "file-snapshot-relative-"))
+    );
+    const otherDir = realpathSync(
+      mkdtempSync(join(tmpdir(), "file-snapshot-other-"))
+    );
+    try {
+      process.chdir(worktree);
+      const relativeStore = new FileSnapshotStore(".state", {
+        autoGitignore: false,
+      });
+
+      expect(relativeStore.rootDir).toBe(join(worktree, ".state"));
+      expect(relativeStore.sessionsDir).toBe(
+        join(worktree, ".state", "sessions")
+      );
+
+      process.chdir(otherDir);
+      await relativeStore.save("session-abc", {
+        messages: [],
+        revision: 0,
+        contextLimit: 0,
+        systemPromptTokens: 0,
+        toolSchemasTokens: 0,
+      });
+
+      expect(
+        existsSync(join(worktree, ".state", "sessions", "session-abc.jsonl"))
+      ).toBe(true);
+      expect(
+        existsSync(join(otherDir, ".state", "sessions", "session-abc.jsonl"))
+      ).toBe(false);
+    } finally {
+      process.chdir(originalCwd);
+      rmSync(worktree, { recursive: true, force: true });
+      rmSync(otherDir, { recursive: true, force: true });
+    }
+  });
+
+  it("writes sessions into the <root>/sessions subdirectory", async () => {
+    const snapshot: HistorySnapshot = {
+      messages: [],
+      revision: 0,
+      contextLimit: 0,
+      systemPromptTokens: 0,
+      toolSchemasTokens: 0,
+    };
+    await store.save("session-abc", snapshot);
+
+    const sessionFile = join(tmpDir, "sessions", "session-abc.jsonl");
+    expect(existsSync(sessionFile)).toBe(true);
+  });
+
+  it("appends the top-level dir to the worktree .gitignore by default", () => {
+    const worktree = realpathSync(
+      mkdtempSync(join(tmpdir(), "file-snapshot-worktree-"))
+    );
+    try {
+      mkdirSync(join(worktree, ".git"));
+      const gitignorePath = join(worktree, ".gitignore");
+      writeFileSync(gitignorePath, "node_modules/\n", "utf8");
+      const root = join(worktree, ".test-store");
+      new FileSnapshotStore(root);
+      const contents = readFileSync(gitignorePath, "utf8");
+      expect(contents).toContain(".test-store");
+    } finally {
+      rmSync(worktree, { recursive: true, force: true });
+    }
+  });
+
+  it("skips gitignore update when root dir is outside any git worktree", () => {
+    const outside = realpathSync(
+      mkdtempSync(join(tmpdir(), "file-snapshot-no-repo-"))
+    );
+    try {
+      const gitignorePath = join(outside, ".gitignore");
+      writeFileSync(gitignorePath, "node_modules/\n", "utf8");
+      new FileSnapshotStore(join(outside, ".test-store"));
+      expect(readFileSync(gitignorePath, "utf8")).toBe("node_modules/\n");
+    } finally {
+      rmSync(outside, { recursive: true, force: true });
+    }
   });
 
   it("writes snapshot atomically over existing content", async () => {

--- a/packages/harness/src/file-snapshot-store.ts
+++ b/packages/harness/src/file-snapshot-store.ts
@@ -6,19 +6,38 @@ import {
   rmSync,
   writeFileSync,
 } from "node:fs";
-import { join } from "node:path";
+import { join, resolve } from "node:path";
 import type { MessageLine, SessionFileLine } from "./compaction-types";
+import { ensureDirIgnoredByGit } from "./gitignore-sync";
 import type { HistorySnapshot } from "./history-snapshot";
 import { encodeSessionId, type SessionData } from "./session-store";
 import type { SnapshotStore } from "./snapshot-store";
 import { createRuntimeUUID } from "./uuid";
 
-export class FileSnapshotStore implements SnapshotStore {
-  private readonly baseDir: string;
+export const SESSIONS_SUBDIR = "sessions";
 
-  constructor(baseDir: string) {
-    mkdirSync(baseDir, { recursive: true });
-    this.baseDir = baseDir;
+export interface FileSnapshotStoreOptions {
+  /**
+   * When true (default), append the configured top-level directory to the
+   * nearest ancestor `.gitignore` if not already listed. Best-effort — never
+   * fails initialization. Set to `false` to disable, e.g. in tests or when
+   * writing outside of a git worktree on purpose.
+   */
+  autoGitignore?: boolean;
+}
+
+export class FileSnapshotStore implements SnapshotStore {
+  readonly rootDir: string;
+  readonly sessionsDir: string;
+
+  constructor(rootDir: string, options: FileSnapshotStoreOptions = {}) {
+    this.rootDir = resolve(rootDir);
+    this.sessionsDir = join(this.rootDir, SESSIONS_SUBDIR);
+    mkdirSync(this.sessionsDir, { recursive: true });
+
+    if (options.autoGitignore !== false) {
+      ensureDirIgnoredByGit(this.rootDir);
+    }
   }
 
   load(sessionId: string): Promise<HistorySnapshot | null> {
@@ -109,17 +128,7 @@ export class FileSnapshotStore implements SnapshotStore {
 
   private getFilePath(sessionId: string): string {
     const encoded = encodeSessionId(sessionId);
-    const primary = join(this.baseDir, `${encoded}.jsonl`);
-    if (existsSync(primary)) {
-      return primary;
-    }
-
-    const legacy = join(this.baseDir, `${sessionId}.jsonl`);
-    if (existsSync(legacy)) {
-      return legacy;
-    }
-
-    return primary;
+    return join(this.sessionsDir, `${encoded}.jsonl`);
   }
 
   private loadSession(sessionId: string): SessionData | null {

--- a/packages/harness/src/gitignore-sync.concurrent-worker.mjs
+++ b/packages/harness/src/gitignore-sync.concurrent-worker.mjs
@@ -1,0 +1,9 @@
+import { ensureGitignoreEntry } from "./gitignore-sync.ts";
+
+const [, , gitignorePath, entry] = process.argv;
+if (!(gitignorePath && entry)) {
+  process.exit(2);
+}
+
+ensureGitignoreEntry(gitignorePath, entry);
+process.exit(0);

--- a/packages/harness/src/gitignore-sync.test.ts
+++ b/packages/harness/src/gitignore-sync.test.ts
@@ -1,0 +1,312 @@
+import { fork } from "node:child_process";
+import {
+  mkdirSync,
+  mkdtempSync,
+  readdirSync,
+  readFileSync,
+  realpathSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  ensureDirIgnoredByGit,
+  ensureGitignoreEntry,
+  findNearestGitignore,
+  gitignoreEntryForDir,
+} from "./gitignore-sync";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+
+describe("gitignore-sync", () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = realpathSync(mkdtempSync(join(tmpdir(), "gitignore-sync-test-")));
+  });
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  describe("findNearestGitignore", () => {
+    it("returns null when there is no .git worktree marker", () => {
+      writeFileSync(join(tmpDir, ".gitignore"), "node_modules/\n", "utf8");
+      expect(findNearestGitignore(tmpDir)).toBeNull();
+    });
+
+    it("returns null when .git exists but no .gitignore is present", () => {
+      mkdirSync(join(tmpDir, ".git"));
+      expect(findNearestGitignore(tmpDir)).toBeNull();
+    });
+
+    it("returns the .gitignore at the .git-adjacent worktree root", () => {
+      mkdirSync(join(tmpDir, ".git"));
+      const gitignorePath = join(tmpDir, ".gitignore");
+      writeFileSync(gitignorePath, "node_modules/\n", "utf8");
+      const sub = join(tmpDir, "a", "b");
+      mkdirSync(sub, { recursive: true });
+      expect(findNearestGitignore(sub)).toBe(gitignorePath);
+    });
+
+    it("refuses to fall back to a non-worktree ancestor .gitignore", () => {
+      writeFileSync(join(tmpDir, ".gitignore"), "outer\n", "utf8");
+      const inner = join(tmpDir, "inner");
+      mkdirSync(inner);
+      mkdirSync(join(inner, ".git"));
+      expect(findNearestGitignore(inner)).toBeNull();
+    });
+
+    it("supports `.git` as a file (submodule / git-worktree case)", () => {
+      writeFileSync(
+        join(tmpDir, ".git"),
+        "gitdir: ../.git/worktrees/x\n",
+        "utf8"
+      );
+      const gitignorePath = join(tmpDir, ".gitignore");
+      writeFileSync(gitignorePath, "node_modules/\n", "utf8");
+      expect(findNearestGitignore(tmpDir)).toBe(gitignorePath);
+    });
+  });
+
+  describe("ensureGitignoreEntry", () => {
+    it("appends missing entry and preserves trailing newline", () => {
+      const gitignorePath = join(tmpDir, ".gitignore");
+      writeFileSync(gitignorePath, "node_modules/\n", "utf8");
+
+      const changed = ensureGitignoreEntry(gitignorePath, ".plugsuits");
+
+      expect(changed).toBe(true);
+      expect(readFileSync(gitignorePath, "utf8")).toBe(
+        "node_modules/\n.plugsuits\n"
+      );
+    });
+
+    it("adds missing trailing newline before appending", () => {
+      const gitignorePath = join(tmpDir, ".gitignore");
+      writeFileSync(gitignorePath, "node_modules/", "utf8");
+
+      ensureGitignoreEntry(gitignorePath, ".plugsuits");
+
+      expect(readFileSync(gitignorePath, "utf8")).toBe(
+        "node_modules/\n.plugsuits\n"
+      );
+    });
+
+    it("is idempotent for exact matches", () => {
+      const gitignorePath = join(tmpDir, ".gitignore");
+      writeFileSync(gitignorePath, ".plugsuits\n", "utf8");
+
+      const changed = ensureGitignoreEntry(gitignorePath, ".plugsuits");
+
+      expect(changed).toBe(false);
+      expect(readFileSync(gitignorePath, "utf8")).toBe(".plugsuits\n");
+    });
+
+    it("treats trailing-slash variants as equivalent", () => {
+      const gitignorePath = join(tmpDir, ".gitignore");
+      writeFileSync(gitignorePath, ".plugsuits/\n", "utf8");
+
+      const changed = ensureGitignoreEntry(gitignorePath, ".plugsuits");
+
+      expect(changed).toBe(false);
+    });
+
+    it("ignores comment lines when checking for existing entries", () => {
+      const gitignorePath = join(tmpDir, ".gitignore");
+      writeFileSync(gitignorePath, "# .plugsuits\n", "utf8");
+
+      const changed = ensureGitignoreEntry(gitignorePath, ".plugsuits");
+
+      expect(changed).toBe(true);
+    });
+
+    it("treats negated patterns as non-matching and still appends", () => {
+      const gitignorePath = join(tmpDir, ".gitignore");
+      writeFileSync(gitignorePath, "!.plugsuits\n", "utf8");
+
+      const changed = ensureGitignoreEntry(gitignorePath, ".plugsuits");
+
+      expect(changed).toBe(true);
+      expect(readFileSync(gitignorePath, "utf8")).toBe(
+        "!.plugsuits\n.plugsuits\n"
+      );
+    });
+
+    it("appends correctly to an empty .gitignore", () => {
+      const gitignorePath = join(tmpDir, ".gitignore");
+      writeFileSync(gitignorePath, "", "utf8");
+
+      const changed = ensureGitignoreEntry(gitignorePath, ".plugsuits");
+
+      expect(changed).toBe(true);
+      expect(readFileSync(gitignorePath, "utf8")).toBe(".plugsuits\n");
+    });
+
+    it("preserves CRLF line endings when the file uses them", () => {
+      const gitignorePath = join(tmpDir, ".gitignore");
+      writeFileSync(gitignorePath, "node_modules/\r\n", "utf8");
+
+      const changed = ensureGitignoreEntry(gitignorePath, ".plugsuits");
+
+      expect(changed).toBe(true);
+      expect(readFileSync(gitignorePath, "utf8")).toBe(
+        "node_modules/\r\n.plugsuits\r\n"
+      );
+    });
+
+    it("detects an already-listed entry inside a CRLF file", () => {
+      const gitignorePath = join(tmpDir, ".gitignore");
+      writeFileSync(gitignorePath, "node_modules/\r\n.plugsuits\r\n", "utf8");
+
+      const changed = ensureGitignoreEntry(gitignorePath, ".plugsuits");
+
+      expect(changed).toBe(false);
+    });
+
+    it("returns false when gitignore does not exist", () => {
+      const changed = ensureGitignoreEntry(
+        join(tmpDir, ".gitignore"),
+        ".plugsuits"
+      );
+      expect(changed).toBe(false);
+    });
+
+    it("writes atomically and leaves no temp file behind", () => {
+      const gitignorePath = join(tmpDir, ".gitignore");
+      writeFileSync(gitignorePath, "a\nb\n", "utf8");
+
+      ensureGitignoreEntry(gitignorePath, "c");
+
+      expect(readFileSync(gitignorePath, "utf8")).toBe("a\nb\nc\n");
+      const leftover = readdirSync(tmpDir).filter(
+        (f) => f.startsWith(".gitignore.") && f.endsWith(".tmp")
+      );
+      expect(leftover).toHaveLength(0);
+    });
+
+    it("preserves both updates under concurrent writers (no lost update)", async () => {
+      const gitignorePath = join(tmpDir, ".gitignore");
+      writeFileSync(gitignorePath, "node_modules/\n", "utf8");
+
+      const workerScript = join(HERE, "gitignore-sync.concurrent-worker.mjs");
+      const runWorker = (entry: string): Promise<number> =>
+        new Promise((resolvePromise, rejectPromise) => {
+          const child = fork(workerScript, [gitignorePath, entry], {
+            stdio: "ignore",
+            execArgv: ["--import", "tsx"],
+          });
+          child.on("exit", (code) => {
+            resolvePromise(code ?? -1);
+          });
+          child.on("error", rejectPromise);
+        });
+
+      const [codeA, codeB] = await Promise.all([
+        runWorker(".plugsuits"),
+        runWorker(".cache"),
+      ]);
+
+      expect(codeA).toBe(0);
+      expect(codeB).toBe(0);
+
+      const finalContents = readFileSync(gitignorePath, "utf8");
+      expect(finalContents).toContain("node_modules/");
+      expect(finalContents).toContain(".plugsuits");
+      expect(finalContents).toContain(".cache");
+
+      const leftover = readdirSync(tmpDir).filter(
+        (f) => f.startsWith(".gitignore.") && f.endsWith(".tmp")
+      );
+      expect(leftover).toHaveLength(0);
+      expect(readdirSync(tmpDir)).not.toContain(".gitignore.lock");
+    });
+  });
+
+  describe("gitignoreEntryForDir", () => {
+    it("returns POSIX-style relative path", () => {
+      const gitignorePath = join(tmpDir, ".gitignore");
+      const target = join(tmpDir, "nested", ".plugsuits");
+      expect(gitignoreEntryForDir(gitignorePath, target)).toBe(
+        "nested/.plugsuits"
+      );
+    });
+
+    it("returns null when target escapes gitignore directory", () => {
+      const inner = join(tmpDir, "inner");
+      mkdirSync(inner);
+      const gitignorePath = join(inner, ".gitignore");
+      const target = join(tmpDir, ".plugsuits");
+      expect(gitignoreEntryForDir(gitignorePath, target)).toBeNull();
+    });
+
+    it("returns null when target is the gitignore directory itself", () => {
+      const gitignorePath = join(tmpDir, ".gitignore");
+      expect(gitignoreEntryForDir(gitignorePath, tmpDir)).toBeNull();
+    });
+  });
+
+  describe("ensureDirIgnoredByGit", () => {
+    it("writes to the worktree gitignore containing the target dir, ignoring cwd", () => {
+      const worktree = join(tmpDir, "repo");
+      mkdirSync(worktree);
+      mkdirSync(join(worktree, ".git"));
+      const gitignorePath = join(worktree, ".gitignore");
+      writeFileSync(gitignorePath, "node_modules/\n", "utf8");
+
+      const originalCwd = process.cwd();
+      const elsewhere = join(tmpDir, "elsewhere");
+      mkdirSync(elsewhere);
+      process.chdir(elsewhere);
+      try {
+        const target = join(worktree, ".plugsuits");
+        const changed = ensureDirIgnoredByGit(target);
+        expect(changed).toBe(true);
+        expect(readFileSync(gitignorePath, "utf8")).toContain(".plugsuits");
+      } finally {
+        process.chdir(originalCwd);
+      }
+    });
+
+    it("refuses to write when the target is outside any git worktree", () => {
+      const outside = join(tmpDir, "no-repo");
+      mkdirSync(outside);
+      const gitignorePath = join(outside, ".gitignore");
+      writeFileSync(gitignorePath, "node_modules/\n", "utf8");
+
+      const changed = ensureDirIgnoredByGit(join(outside, ".plugsuits"));
+
+      expect(changed).toBe(false);
+      expect(readFileSync(gitignorePath, "utf8")).toBe("node_modules/\n");
+    });
+
+    it("refuses to write when target escapes the worktree root", () => {
+      const outer = join(tmpDir, "outer");
+      const worktree = join(outer, "repo");
+      mkdirSync(worktree, { recursive: true });
+      mkdirSync(join(worktree, ".git"));
+      const gitignorePath = join(worktree, ".gitignore");
+      writeFileSync(gitignorePath, "node_modules/\n", "utf8");
+
+      const changed = ensureDirIgnoredByGit(join(outer, ".plugsuits"));
+
+      expect(changed).toBe(false);
+      expect(readFileSync(gitignorePath, "utf8")).toBe("node_modules/\n");
+    });
+
+    it("handles a target dir that does not exist yet (anchors to parent)", () => {
+      mkdirSync(join(tmpDir, ".git"));
+      const gitignorePath = join(tmpDir, ".gitignore");
+      writeFileSync(gitignorePath, "node_modules/\n", "utf8");
+
+      const future = join(tmpDir, ".plugsuits");
+      const changed = ensureDirIgnoredByGit(future);
+
+      expect(changed).toBe(true);
+      expect(readFileSync(gitignorePath, "utf8")).toContain(".plugsuits");
+    });
+  });
+});

--- a/packages/harness/src/gitignore-sync.ts
+++ b/packages/harness/src/gitignore-sync.ts
@@ -1,0 +1,268 @@
+import { randomUUID } from "node:crypto";
+import {
+  closeSync,
+  existsSync,
+  openSync,
+  readFileSync,
+  renameSync,
+  rmSync,
+  statSync,
+  writeFileSync,
+} from "node:fs";
+import { dirname, isAbsolute, relative, resolve, sep } from "node:path";
+
+const BACKSLASH_PATTERN = /\\/g;
+const TRAILING_SLASH_PATTERN = /\/+$/;
+const CRLF_DETECT_PATTERN = /\r\n/;
+const LINE_SPLIT_PATTERN = /\r?\n/;
+
+const LOCK_SUFFIX = ".lock";
+const LOCK_ACQUIRE_TIMEOUT_MS = 5000;
+const LOCK_STALE_THRESHOLD_MS = 30_000;
+const LOCK_POLL_INTERVAL_MS = 20;
+
+function hasGitWorktreeMarker(dir: string): boolean {
+  const gitPath = resolve(dir, ".git");
+  if (!existsSync(gitPath)) {
+    return false;
+  }
+  try {
+    const st = statSync(gitPath);
+    return st.isDirectory() || st.isFile();
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Locate the `.gitignore` at the git worktree root containing `startDir`.
+ *
+ * Walks upward from `startDir` and returns the first directory that contains
+ * BOTH a `.git` marker (directory or file, to support submodules/worktrees)
+ * AND a `.gitignore`. Returns `null` if no git worktree is found, or if the
+ * worktree root has no `.gitignore`. We deliberately refuse to fall back to
+ * an unrelated ancestor `.gitignore` — that would risk polluting a parent
+ * repo's or a user's home-level ignore file.
+ */
+export function findNearestGitignore(startDir: string): string | null {
+  let current = resolve(startDir);
+  while (true) {
+    if (hasGitWorktreeMarker(current)) {
+      const gitignorePath = resolve(current, ".gitignore");
+      return existsSync(gitignorePath) ? gitignorePath : null;
+    }
+    const parent = dirname(current);
+    if (parent === current) {
+      return null;
+    }
+    current = parent;
+  }
+}
+
+function normalizeEntry(entry: string): string {
+  return entry
+    .replace(BACKSLASH_PATTERN, "/")
+    .replace(TRAILING_SLASH_PATTERN, "");
+}
+
+function splitLines(content: string): string[] {
+  return content.split(LINE_SPLIT_PATTERN);
+}
+
+function detectLineEnding(content: string): "\r\n" | "\n" {
+  return CRLF_DETECT_PATTERN.test(content) ? "\r\n" : "\n";
+}
+
+function isEffectiveIgnoreLine(line: string, normalizedEntry: string): boolean {
+  const trimmed = line.trim();
+  if (trimmed.length === 0 || trimmed.startsWith("#")) {
+    return false;
+  }
+  // Negation lines (`!foo`) are whitelists — they re-include a path rather
+  // than declare it as ignored, so they must not suppress our append.
+  if (trimmed.startsWith("!")) {
+    return false;
+  }
+  return normalizeEntry(trimmed) === normalizedEntry;
+}
+
+function sleepSync(ms: number): void {
+  const end = Date.now() + ms;
+  while (Date.now() < end) {
+    // Busy-wait is acceptable for sub-100ms lock contention. The lock window
+    // is bounded by a single small file rename, so spin time is negligible.
+  }
+}
+
+function tryRemoveStaleLock(lockPath: string): boolean {
+  try {
+    const st = statSync(lockPath);
+    const ageMs = Date.now() - st.mtimeMs;
+    if (ageMs > LOCK_STALE_THRESHOLD_MS) {
+      rmSync(lockPath, { force: true });
+      return true;
+    }
+  } catch {
+    // Lock vanished between existsSync and stat — treat as released.
+    return true;
+  }
+  return false;
+}
+
+function acquireLock(lockPath: string): number | null {
+  const deadline = Date.now() + LOCK_ACQUIRE_TIMEOUT_MS;
+  while (true) {
+    try {
+      return openSync(lockPath, "wx");
+    } catch (error) {
+      const code = (error as NodeJS.ErrnoException).code;
+      if (code !== "EEXIST") {
+        throw error;
+      }
+      if (tryRemoveStaleLock(lockPath)) {
+        continue;
+      }
+      if (Date.now() >= deadline) {
+        return null;
+      }
+      sleepSync(LOCK_POLL_INTERVAL_MS);
+    }
+  }
+}
+
+function releaseLock(lockPath: string, fd: number): void {
+  try {
+    closeSync(fd);
+  } catch {
+    // Closing a lock fd that was already invalidated is non-fatal.
+  }
+  try {
+    rmSync(lockPath, { force: true });
+  } catch {
+    // A stale-lock sweep elsewhere may have already removed it.
+  }
+}
+
+/**
+ * Atomically, idempotently ensure `entry` is present in `gitignorePath`.
+ *
+ * Algorithm:
+ *  1. Acquire an exclusive lock via `openSync(`${path}.lock`, "wx")`. This is
+ *     an atomic create-or-fail on POSIX and NTFS. Retry briefly on contention.
+ *     Sweep stale locks (older than 30s) to survive crashed writers.
+ *  2. Under the lock: read current content, decide whether to append.
+ *  3. If appending, write a sibling temp file and `renameSync` it over the
+ *     target. The rename is atomic on the same filesystem.
+ *  4. Release the lock.
+ *
+ * Returns `true` iff the file was modified. If the lock can't be acquired
+ * within the timeout, returns `false` (best-effort — gitignore maintenance
+ * must never block session initialization).
+ *
+ * The lock prevents the classic lost-update race:
+ * - Without a lock, two writers each read the file, each compute `original +
+ *   entryA` vs `original + entryB`, and the later `renameSync` silently
+ *   overwrites the earlier one.
+ * - With the lock, the second writer's read sees the first writer's append
+ *   already persisted and adds its own entry on top.
+ */
+export function ensureGitignoreEntry(
+  gitignorePath: string,
+  entry: string
+): boolean {
+  const normalizedEntry = normalizeEntry(entry);
+  if (normalizedEntry.length === 0) {
+    return false;
+  }
+
+  if (!existsSync(gitignorePath)) {
+    return false;
+  }
+
+  const lockPath = `${gitignorePath}${LOCK_SUFFIX}`;
+  const lockFd = acquireLock(lockPath);
+  if (lockFd === null) {
+    return false;
+  }
+
+  try {
+    const content = readFileSync(gitignorePath, "utf8");
+    const lines = splitLines(content);
+    const alreadyListed = lines.some((line) =>
+      isEffectiveIgnoreLine(line, normalizedEntry)
+    );
+    if (alreadyListed) {
+      return false;
+    }
+
+    const eol = detectLineEnding(content);
+    const needsLeadingEol =
+      content.length > 0 &&
+      !content.endsWith("\n") &&
+      !content.endsWith("\r\n");
+    const newContent = `${content}${needsLeadingEol ? eol : ""}${normalizedEntry}${eol}`;
+
+    const tempPath = `${gitignorePath}.${randomUUID()}.tmp`;
+    writeFileSync(tempPath, newContent, "utf8");
+    renameSync(tempPath, gitignorePath);
+    return true;
+  } finally {
+    releaseLock(lockPath, lockFd);
+  }
+}
+
+/**
+ * Compute the gitignore entry path for `targetDir` relative to the directory
+ * containing `gitignorePath`. Returns a POSIX-style path, or `null` if the
+ * target escapes the gitignore's directory tree (we never write escaping
+ * paths into a parent `.gitignore`).
+ */
+export function gitignoreEntryForDir(
+  gitignorePath: string,
+  targetDir: string
+): string | null {
+  const gitignoreDir = dirname(resolve(gitignorePath));
+  const absoluteTarget = isAbsolute(targetDir)
+    ? resolve(targetDir)
+    : resolve(process.cwd(), targetDir);
+  const rel = relative(gitignoreDir, absoluteTarget);
+  if (rel.length === 0) {
+    return null;
+  }
+  if (rel.startsWith("..") || isAbsolute(rel)) {
+    return null;
+  }
+  return rel.split(sep).join("/");
+}
+
+/**
+ * Best-effort: if `targetDir` lives inside a git worktree, ensure it is
+ * listed in that worktree's `.gitignore`. Search is anchored at `targetDir`
+ * (falling back to the parent directory if `targetDir` does not exist yet),
+ * never at `process.cwd()` — the relevant repo is the one containing the
+ * storage directory, not the one hosting the caller.
+ *
+ * All failures are swallowed; gitignore maintenance must never block session
+ * initialization. Returns `true` iff the file was modified.
+ */
+export function ensureDirIgnoredByGit(targetDir: string): boolean {
+  try {
+    const absoluteTarget = isAbsolute(targetDir)
+      ? resolve(targetDir)
+      : resolve(process.cwd(), targetDir);
+    const searchStart = existsSync(absoluteTarget)
+      ? absoluteTarget
+      : dirname(absoluteTarget);
+    const gitignorePath = findNearestGitignore(searchStart);
+    if (gitignorePath === null) {
+      return false;
+    }
+    const entry = gitignoreEntryForDir(gitignorePath, absoluteTarget);
+    if (entry === null) {
+      return false;
+    }
+    return ensureGitignoreEntry(gitignorePath, entry);
+  } catch {
+    return false;
+  }
+}

--- a/packages/harness/src/index.ts
+++ b/packages/harness/src/index.ts
@@ -111,7 +111,14 @@ export type {
   ToolApprovalContext,
   ToolSourceCallContext,
 } from "./execution-context";
-export { FileSnapshotStore } from "./file-snapshot-store";
+export type { FileSnapshotStoreOptions } from "./file-snapshot-store";
+export { FileSnapshotStore, SESSIONS_SUBDIR } from "./file-snapshot-store";
+export {
+  ensureDirIgnoredByGit,
+  ensureGitignoreEntry,
+  findNearestGitignore,
+  gitignoreEntryForDir,
+} from "./gitignore-sync";
 export type {
   HistorySnapshot,
   SerializedMessage,

--- a/packages/harness/src/subpath/sessions.ts
+++ b/packages/harness/src/subpath/sessions.ts
@@ -3,7 +3,14 @@ export type {
   OverflowRecoveryResult,
 } from "../checkpoint-history";
 export { CheckpointHistory } from "../checkpoint-history";
-export { FileSnapshotStore } from "../file-snapshot-store";
+export type { FileSnapshotStoreOptions } from "../file-snapshot-store";
+export { FileSnapshotStore, SESSIONS_SUBDIR } from "../file-snapshot-store";
+export {
+  ensureDirIgnoredByGit,
+  ensureGitignoreEntry,
+  findNearestGitignore,
+  gitignoreEntryForDir,
+} from "../gitignore-sync";
 export type { HistorySnapshot, SerializedMessage } from "../history-snapshot";
 export { deserializeMessage, serializeMessage } from "../history-snapshot";
 export { SessionManager } from "../session";

--- a/packages/minimal-agent/README.md
+++ b/packages/minimal-agent/README.md
@@ -13,7 +13,7 @@ Optional:
 - `AI_BASE_URL`
 - `AI_MODEL`
 - `AI_CONTEXT_LIMIT`
-- `SESSION_DIR` — directory where session snapshots are written. Defaults to `.minimal-agent/sessions` in the current working directory.
+- `MINIMAL_AGENT_DIR` — top-level directory for agent state (sessions, memory, etc.). Defaults to `.minimal-agent` in the current working directory. Session snapshots are written to `<MINIMAL_AGENT_DIR>/sessions/`. If a `.gitignore` exists nearby, the directory is appended automatically.
 
 ## Scripts
 

--- a/packages/minimal-agent/env.ts
+++ b/packages/minimal-agent/env.ts
@@ -7,7 +7,7 @@ export const env = createEnv({
     AI_BASE_URL: z.url().default("https://apis.opengateway.ai/v1"),
     AI_MODEL: z.string().min(1).default("openai/gpt-5.4-mini"),
     AI_CONTEXT_LIMIT: z.coerce.number().int().positive().default(128_000),
-    SESSION_DIR: z.string().min(1).default(".minimal-agent/sessions"),
+    MINIMAL_AGENT_DIR: z.string().min(1).default(".minimal-agent"),
   },
   runtimeEnv: process.env,
   emptyStringAsUndefined: true,

--- a/packages/minimal-agent/index.ts
+++ b/packages/minimal-agent/index.ts
@@ -142,7 +142,9 @@ const agent = defineAgent({
 const runtime = await createAgentRuntime({
   name: "minimal-agent",
   agents: [agent],
-  persistence: { snapshotStore: new FileSnapshotStore(env.SESSION_DIR) },
+  persistence: {
+    snapshotStore: new FileSnapshotStore(env.MINIMAL_AGENT_DIR),
+  },
 });
 const session = await runtime.openSession();
 

--- a/packages/tgbot/src/agent.ts
+++ b/packages/tgbot/src/agent.ts
@@ -20,7 +20,7 @@ const provider = createOpenAICompatible({
   apiKey: env.AI_API_KEY,
 });
 const model = provider.chatModel(env.AI_MODEL);
-const snapshotStore = new FileSnapshotStore(env.SESSION_DIR);
+const snapshotStore = new FileSnapshotStore(env.TGBOT_DIR);
 const summarize = createModelSummarizer(model);
 const threadTrackers = new Map<string, SessionMemoryTracker>();
 const threadSaveChains = new Map<string, Promise<void>>();

--- a/packages/tgbot/src/env.ts
+++ b/packages/tgbot/src/env.ts
@@ -4,6 +4,8 @@ import { harnessEnv } from "@ai-sdk-tool/harness";
 import { createEnv } from "@t3-oss/env-core";
 import { z } from "zod";
 
+const DEFAULT_TGBOT_DIR = join(tmpdir(), "tgbot");
+
 const TRAILING_SLASHES = /\/+$/;
 
 export const env = createEnv({
@@ -30,7 +32,7 @@ export const env = createEnv({
           .map((w) => w.trim().toLowerCase())
           .filter(Boolean)
       ),
-    SESSION_DIR: z.string().default(join(tmpdir(), "tgbot-sessions")),
+    TGBOT_DIR: z.string().min(1).default(DEFAULT_TGBOT_DIR),
     LOG_LEVEL: z
       .enum(["debug", "info", "warn", "error", "silent"])
       .default("info"),


### PR DESCRIPTION
## Summary

- Reshape `FileSnapshotStore` so it owns its on-disk layout: pass a top-level directory (`.plugsuits`, `.minimal-agent`, ...) instead of a pre-resolved `/sessions` path. The store manages `<root>/sessions/*.jsonl` itself and exposes `rootDir` / `sessionsDir` getters for consumers that want to co-locate related files (e.g. session memory).
- Auto-gitignore: when the root dir lives inside a git worktree, the store appends the top-level dir to that worktree's `.gitignore` if not already listed. Opt out with `{ autoGitignore: false }`.
- Migrate all in-repo consumers (`cea`, `minimal-agent`, `tgbot`) to the new contract. No backward compatibility is kept for the legacy session-file path or the old env var names.

## Motivation

Every consumer was reimplementing the same few lines: resolve a root dir, `mkdirSync(.../sessions)`, pass `.../sessions` into the store, and then separately remember to add the state dir to `.gitignore`. The last step was usually forgotten, and agent state directories leaked into commits.

This PR pushes both responsibilities into the store:

1. **Convention over configuration** — consumers stop thinking about the `/sessions` subpath. They hand over a top-level dir; the store lays out its files.
2. **Safe-by-default persistence** — state dirs are auto-ignored on the way in, so `.plugsuits/`, `.minimal-agent/`, `<tmpdir>/tgbot/` can't be committed by accident.

## Changes

### `FileSnapshotStore` (core)

- Constructor signature: `new FileSnapshotStore(rootDir, options?)`. `rootDir` is the top-level dir; sessions live at `<rootDir>/sessions/*.jsonl`.
- Public getters: `rootDir`, `sessionsDir` (resolved absolute paths).
- New options type: `FileSnapshotStoreOptions { autoGitignore?: boolean }` (defaults to `true`).
- Removed the undocumented `getFilePath` fallback for unencoded session filenames. Files are always encoded via `encodeSessionId`.

### `gitignore-sync` (new module)

Covered by `packages/harness/src/gitignore-sync.ts` + tests. Exported from both the package root and `@ai-sdk-tool/harness/sessions`:

- `ensureDirIgnoredByGit`, `ensureGitignoreEntry`, `findNearestGitignore`, `gitignoreEntryForDir`.

Design constraints:

| Risk | Mitigation |
|---|---|
| Concurrent writers corrupt `.gitignore` | `.gitignore.lock` via `openSync(path, \"wx\")` serializes writers |
| Crashed writer wedges the next caller | Stale locks older than 30s are reclaimed |
| Partial write leaves `.gitignore` truncated | Temp-file + `rename` swap (atomic on same fs) |
| Mixes LF/CRLF with existing file | Detects and preserves the file's line-ending convention |
| Accidentally modifies parent repo's or home-level `.gitignore` | Refuses to touch any ancestor `.gitignore` that is not at a verified worktree root (sibling `.git` marker) |

### Consumer migration (no backward compat)

| Package | Before | After |
|---|---|---|
| `cea` | hardcoded `.plugsuits/sessions` + explicit `mkdirSync` + manual session-memory path | `new FileSnapshotStore(\".plugsuits\")`; session-memory path derived from `store.sessionsDir` |
| `minimal-agent` | `SESSION_DIR` (default `.minimal-agent/sessions`) | `MINIMAL_AGENT_DIR` (default `.minimal-agent`) |
| `tgbot` | `SESSION_DIR` (default `<tmpdir>/tgbot-sessions`) | `TGBOT_DIR` (default `<tmpdir>/tgbot`) |

### Tests

- Existing `FileSnapshotStore` suite passes `{ autoGitignore: false }` to stay hermetic.
- New cases: `rootDir` / `sessionsDir` getter exposure, `<root>/sessions/` layout, auto-gitignore inside a fake worktree, and the skip path when the root is outside any worktree.
- Standalone `gitignore-sync.test.ts` covers concurrency (via a worker mjs), stale-lock reclaim, LF/CRLF preservation, and the worktree-root guard.

### Docs

- `AGENTS.md` — updated `FileSnapshotStore` example and auto-gitignore semantics.
- `packages/harness/README.md` — sample path updated.
- `packages/minimal-agent/README.md` — documents the new `MINIMAL_AGENT_DIR`.

## Changeset

`patch` bump for `@ai-sdk-tool/harness`, `@plugsuits/minimal-agent`, `@plugsuits/tgbot`, `plugsuits`.

## Verification

- `pnpm run typecheck` — all 6 packages green (full turbo cache).
- `pnpm --filter @ai-sdk-tool/harness test` — 727/727 passing (47 files).

## Migration notes for downstream consumers

If you were constructing `FileSnapshotStore` directly:

```diff
- new FileSnapshotStore(\".plugsuits/sessions\")
+ new FileSnapshotStore(\".plugsuits\")
```

If you relied on `SESSION_DIR`:

- `minimal-agent`: set `MINIMAL_AGENT_DIR` instead.
- `tgbot`: set `TGBOT_DIR` instead.

To disable the auto-gitignore behavior (e.g. in tests or non-git environments):

```ts
new FileSnapshotStore(dir, { autoGitignore: false })
```

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
`FileSnapshotStore` now owns its on-disk layout: pass a top-level state dir and it writes snapshots to `<root>/sessions/*.jsonl`. It resolves the root dir at construction (stable if `process.cwd()` changes) and best-effort appends the dir to the worktree `.gitignore` (safe and atomic), which you can disable.

- New Features
  - `@ai-sdk-tool/harness`: `new FileSnapshotStore(rootDir, { autoGitignore = true })`; resolves `rootDir` on construct, exposes `rootDir` and `sessionsDir`, always uses `encodeSessionId`; exports `SESSIONS_SUBDIR`.
  - Auto-gitignore anchored to the target dir’s worktree (not `cwd`); concurrency-safe lock + atomic writes, preserves LF/CRLF, verifies worktree root, supports `.git` file/dir, never blocks initialization (best-effort).
  - Utilities exported: `ensureDirIgnoredByGit`, `ensureGitignoreEntry`, `findNearestGitignore`, `gitignoreEntryForDir`.

- Migration
  - Replace `new FileSnapshotStore("<dir>/sessions")` with `new FileSnapshotStore("<dir>")`; use `store.sessionsDir` for co-located files.
  - `@plugsuits/minimal-agent`: `SESSION_DIR` → `MINIMAL_AGENT_DIR` (default `.minimal-agent`).
  - `@plugsuits/tgbot`: `SESSION_DIR` → `TGBOT_DIR` (default `<tmpdir>/tgbot`).
  - To disable auto-gitignore: `new FileSnapshotStore(dir, { autoGitignore: false })`.

<sup>Written for commit b1dd640f1362056a8f22534b5cbe06e607013f4f. Summary will update on new commits. <a href="https://cubic.dev/pr/minpeter/plugsuits/pull/123?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

