### PR TITLE
[codex] Keep harness runtime importable at the edge

### DIFF
--- a/.changeset/minimal-agent-dev-watch.md
+++ b/.changeset/minimal-agent-dev-watch.md
@@ -2,4 +2,4 @@
 "@ai-sdk-tool/harness": patch
 ---
 
-Fix dotenv loading from source-condition ESM entrypoints on Node 24.
+Keep the runtime subpath importable in edge runtimes by removing unconditional Node-only dotenv, skills, MCP, and crypto imports from the core runtime graph.

--- a/.changeset/minimal-agent-dev-watch.md
+++ b/.changeset/minimal-agent-dev-watch.md
@@ -1,0 +1,5 @@
+---
+"@ai-sdk-tool/harness": patch
+---
+
+Fix dotenv loading from source-condition ESM entrypoints on Node 24.

--- a/packages/harness/package.json
+++ b/packages/harness/package.json
@@ -54,6 +54,11 @@
       "@ai-sdk-tool/source": "./src/subpath/utils.ts",
       "import": "./dist/subpath/utils.js",
       "types": "./dist/subpath/utils.d.ts"
+    },
+    "./env-node": {
+      "@ai-sdk-tool/source": "./src/env-node.ts",
+      "import": "./dist/env-node.js",
+      "types": "./dist/env-node.d.ts"
     }
   },
   "files": [

--- a/packages/harness/src/agent.ts
+++ b/packages/harness/src/agent.ts
@@ -6,7 +6,6 @@
 import { streamText, tool } from "ai";
 import { AgentError, AgentErrorCode } from "./errors";
 import type { AgentExecutionContext } from "./execution-context";
-import { resolveMCPOption } from "./mcp-init";
 import type { ToolDefinition, ToolSource } from "./tool-source";
 import type {
   Agent,
@@ -236,6 +235,7 @@ export async function createAgent(config: AgentConfig): Promise<Agent> {
   };
 
   if (config.mcp !== undefined) {
+    const { resolveMCPOption } = await import("./mcp-init");
     const resolved = await resolveMCPOption(config.mcp, mergedTools);
     mergedTools = resolved.tools;
     const previousClose = closeFn;

--- a/packages/harness/src/checkpoint-history.ts
+++ b/packages/harness/src/checkpoint-history.ts
@@ -1,4 +1,3 @@
-import { randomUUID } from "node:crypto";
 import type { ModelMessage, TextPart } from "ai";
 import { calculateCompactionSplitIndex } from "./compaction-planner";
 import {
@@ -41,6 +40,7 @@ import {
 } from "./token-utils";
 import { adjustSplitIndexForToolPairs } from "./tool-pair-validation";
 import { progressivePrune, pruneToolOutputs } from "./tool-pruning";
+import { createRuntimeUUID } from "./uuid";
 
 const TOOL_RESULT_CHARS_PER_TOKEN_INTERNAL = 6;
 
@@ -914,7 +914,7 @@ export class CheckpointHistory {
       : replayMessage;
 
     const summaryMessage: CheckpointMessage = {
-      id: randomUUID(),
+      id: createRuntimeUUID(),
       createdAt: Date.now(),
       isSummary: true,
       isSummaryMessage: true,
@@ -928,7 +928,7 @@ export class CheckpointHistory {
       effectiveReplayMessage
     );
     const continuationMessage: CheckpointMessage = {
-      id: randomUUID(),
+      id: createRuntimeUUID(),
       createdAt: Date.now(),
       isSummary: false,
       isSummaryMessage: false,
@@ -2348,7 +2348,7 @@ export class CheckpointHistory {
     }
 
     const summaryMessage: CheckpointMessage = {
-      id: randomUUID(),
+      id: createRuntimeUUID(),
       createdAt: Date.now(),
       isSummary: true,
       isSummaryMessage: true,
@@ -2543,7 +2543,7 @@ export class CheckpointHistory {
     originalContent?: string
   ): CheckpointMessage {
     return {
-      id: randomUUID(),
+      id: createRuntimeUUID(),
       createdAt: Date.now(),
       isSummary: false,
       isSummaryMessage: false,

--- a/packages/harness/src/env-node.ts
+++ b/packages/harness/src/env-node.ts
@@ -1,0 +1,33 @@
+import { existsSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { loadEnvFileCompat } from "./env-file";
+
+const findWorkspaceRootEnv = (startDir: string): string | null => {
+  let current = resolve(startDir);
+
+  while (true) {
+    if (existsSync(resolve(current, "pnpm-workspace.yaml"))) {
+      return resolve(current, ".env");
+    }
+
+    const parent = dirname(current);
+    if (parent === current) {
+      return null;
+    }
+    current = parent;
+  }
+};
+
+/** Call this only from Node.js entry points (CLI, test harness). Safe to omit in edge runtimes. */
+export const loadDotEnvFilesIfAvailable = (startDir = process.cwd()): void => {
+  const envFileCandidates = [
+    resolve(startDir, ".env"),
+    findWorkspaceRootEnv(startDir),
+  ].filter((envPath): envPath is string => envPath !== null);
+
+  for (const envPath of new Set(envFileCandidates)) {
+    if (existsSync(envPath)) {
+      loadEnvFileCompat(envPath);
+    }
+  }
+};

--- a/packages/harness/src/env.ts
+++ b/packages/harness/src/env.ts
@@ -1,37 +1,11 @@
-import { existsSync } from "node:fs";
-import { dirname, resolve } from "node:path";
 import { createEnv } from "@t3-oss/env-core";
 import { z } from "zod";
-import { loadEnvFileCompat } from "./env-file";
 
-/** Call this only from Node.js entry points (CLI, test harness). Safe to omit in edge runtimes. */
-export const loadDotEnvFilesIfAvailable = (): void => {
-  const findWorkspaceRootEnv = (startDir: string): string | null => {
-    let current = resolve(startDir);
-
-    while (true) {
-      if (existsSync(resolve(current, "pnpm-workspace.yaml"))) {
-        return resolve(current, ".env");
-      }
-
-      const parent = dirname(current);
-      if (parent === current) {
-        return null;
-      }
-      current = parent;
-    }
-  };
-
-  const envFileCandidates = [
-    resolve(process.cwd(), ".env"),
-    findWorkspaceRootEnv(process.cwd()),
-  ].filter((envPath): envPath is string => envPath !== null);
-
-  for (const envPath of new Set(envFileCandidates)) {
-    if (existsSync(envPath)) {
-      loadEnvFileCompat(envPath);
-    }
+const getRuntimeEnv = (): Record<string, string | undefined> => {
+  if (typeof process === "undefined") {
+    return {};
   }
+  return process.env;
 };
 
 export const env = createEnv({
@@ -52,6 +26,6 @@ export const env = createEnv({
     /** Log token usage per summarizer call. */
     DEBUG_TOKENS: z.stringbool().default(false),
   },
-  runtimeEnv: process.env,
+  runtimeEnv: getRuntimeEnv(),
   emptyStringAsUndefined: true,
 });

--- a/packages/harness/src/env.ts
+++ b/packages/harness/src/env.ts
@@ -1,14 +1,11 @@
+import { existsSync } from "node:fs";
+import { dirname, resolve } from "node:path";
 import { createEnv } from "@t3-oss/env-core";
 import { z } from "zod";
 import { loadEnvFileCompat } from "./env-file";
 
 /** Call this only from Node.js entry points (CLI, test harness). Safe to omit in edge runtimes. */
 export const loadDotEnvFilesIfAvailable = (): void => {
-  // eslint-disable-next-line @typescript-eslint/no-require-imports
-  const { existsSync } = require("node:fs") as typeof import("node:fs");
-  // eslint-disable-next-line @typescript-eslint/no-require-imports
-  const { dirname, resolve } = require("node:path") as typeof import("node:path");
-
   const findWorkspaceRootEnv = (startDir: string): string | null => {
     let current = resolve(startDir);
 

--- a/packages/harness/src/file-snapshot-store.ts
+++ b/packages/harness/src/file-snapshot-store.ts
@@ -1,4 +1,3 @@
-import { randomUUID } from "node:crypto";
 import {
   existsSync,
   mkdirSync,
@@ -12,6 +11,7 @@ import type { MessageLine, SessionFileLine } from "./compaction-types";
 import type { HistorySnapshot } from "./history-snapshot";
 import { encodeSessionId, type SessionData } from "./session-store";
 import type { SnapshotStore } from "./snapshot-store";
+import { createRuntimeUUID } from "./uuid";
 
 export class FileSnapshotStore implements SnapshotStore {
   private readonly baseDir: string;
@@ -52,7 +52,7 @@ export class FileSnapshotStore implements SnapshotStore {
 
   save(sessionId: string, snapshot: HistorySnapshot): Promise<void> {
     const filePath = this.getFilePath(sessionId);
-    const tempFilePath = `${filePath}.${randomUUID()}.tmp`;
+    const tempFilePath = `${filePath}.${createRuntimeUUID()}.tmp`;
     const lines: SessionFileLine[] = [
       {
         type: "header",

--- a/packages/harness/src/package-exports.test.ts
+++ b/packages/harness/src/package-exports.test.ts
@@ -47,5 +47,8 @@ describe("package exports", () => {
     expect(exportsMap["./utils"]?.["@ai-sdk-tool/source"]).toBe(
       "./src/subpath/utils.ts"
     );
+    expect(exportsMap["./env-node"]?.["@ai-sdk-tool/source"]).toBe(
+      "./src/env-node.ts"
+    );
   });
 });

--- a/packages/harness/src/preferences-store.ts
+++ b/packages/harness/src/preferences-store.ts
@@ -1,4 +1,3 @@
-import { randomUUID } from "node:crypto";
 import {
   mkdirSync,
   readFileSync,
@@ -8,6 +7,7 @@ import {
 } from "node:fs";
 import { homedir } from "node:os";
 import { dirname, join } from "node:path";
+import { createRuntimeUUID } from "./uuid";
 
 export interface PreferencesStore<T> {
   clear(): Promise<void>;
@@ -73,7 +73,7 @@ export class FilePreferencesStore<T> implements PreferencesStore<T> {
 
   save(preferences: T): Promise<void> {
     mkdirSync(dirname(this.filePath), { recursive: true });
-    const tempFilePath = `${this.filePath}.${randomUUID()}.tmp`;
+    const tempFilePath = `${this.filePath}.${createRuntimeUUID()}.tmp`;
     writeFileSync(
       tempFilePath,
       `${JSON.stringify(preferences, null, 2)}\n`,

--- a/packages/harness/src/runtime/agent-session.ts
+++ b/packages/harness/src/runtime/agent-session.ts
@@ -1,5 +1,3 @@
-import { randomUUID } from "node:crypto";
-
 import { CheckpointHistory } from "../checkpoint-history";
 import type { Command } from "../commands";
 import { runAgentLoop } from "../loop";
@@ -7,6 +5,7 @@ import type { SessionManager } from "../session";
 import type { SkillInfo } from "../skills";
 import type { SnapshotStore } from "../snapshot-store";
 import type { Agent, AgentConfig, RunnableAgent } from "../types";
+import { createRuntimeUUID } from "../uuid";
 import type {
   AgentHistoryConfig,
   AgentSession,
@@ -219,7 +218,9 @@ class AgentSessionImpl<TAgentName extends string, TContext>
     const previousSessionId = this.currentSessionId;
     const nextSessionId =
       options?.sessionId ??
-      (this.sessionManager ? this.sessionManager.initialize() : randomUUID());
+      (this.sessionManager
+        ? this.sessionManager.initialize()
+        : createRuntimeUUID());
 
     this.currentSessionId = nextSessionId;
     this.history.resetForSession(nextSessionId);
@@ -235,7 +236,7 @@ class AgentSessionImpl<TAgentName extends string, TContext>
   async fork(options?: {
     sessionId?: string;
   }): Promise<AgentSession<TAgentName, TContext>> {
-    const newSessionId = options?.sessionId ?? randomUUID();
+    const newSessionId = options?.sessionId ?? createRuntimeUUID();
     const snapshot = this.history.snapshot();
     const newHistory = new CheckpointHistory({
       ...this.historyDefaults,

--- a/packages/harness/src/runtime/create-runtime.ts
+++ b/packages/harness/src/runtime/create-runtime.ts
@@ -1,18 +1,37 @@
 import { createAgent } from "../agent";
 import { CheckpointHistory } from "../checkpoint-history";
 import { createModelSummarizer } from "../compaction-prompts";
-import { loadDotEnvFilesIfAvailable } from "../env";
 import { SessionManager } from "../session";
-import { SkillsEngine } from "../skills";
+import type { SkillInfo } from "../skills";
 import type { Agent } from "../types";
 import { createAgentSession } from "./agent-session";
 import type {
   AgentRuntime,
   AgentRuntimeConfig,
   AgentSession,
+  AgentSkillsConfig,
   DefineAgentContext,
   DefinedAgent,
 } from "./types";
+
+const getDefaultCwd = (): string => {
+  if (typeof process === "undefined") {
+    return "/";
+  }
+
+  try {
+    return process.cwd();
+  } catch {
+    return "/";
+  }
+};
+
+const loadConfiguredSkills = async (
+  config: AgentSkillsConfig
+): Promise<SkillInfo[]> => {
+  const { SkillsEngine } = await import("../skills");
+  return await new SkillsEngine(config).loadAllSkills();
+};
 
 function assertAgentDefinition<TContext>(
   definition: DefinedAgent<TContext> | undefined,
@@ -43,8 +62,6 @@ export async function createAgentRuntime<
 >(
   config: AgentRuntimeConfig<TAgents, TContext>
 ): Promise<AgentRuntime<TAgents, TContext>> {
-  loadDotEnvFilesIfAvailable();
-
   const agentMap = new Map<string, DefinedAgent<TContext>>();
   for (const definition of config.agents as readonly DefinedAgent<TContext>[]) {
     if (agentMap.has(definition.name)) {
@@ -57,7 +74,7 @@ export async function createAgentRuntime<
   }
 
   const appName = config.name;
-  const cwd = process.cwd();
+  const cwd = config.cwd ?? getDefaultCwd();
   const sharedContext = config.context as TContext;
   const agentInstances = new Map<string, Agent>();
 
@@ -117,7 +134,7 @@ export async function createAgentRuntime<
         )
       : new CheckpointHistory(resolvedHistoryOptions);
     const skills = definition.skills
-      ? await new SkillsEngine(definition.skills).loadAllSkills()
+      ? await loadConfiguredSkills(definition.skills)
       : [];
 
     return createAgentSession({

--- a/packages/harness/src/runtime/runtime-edge-imports.test.ts
+++ b/packages/harness/src/runtime/runtime-edge-imports.test.ts
@@ -1,0 +1,72 @@
+import { existsSync, readFileSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+const SOURCE_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const ENTRYPOINT = join(SOURCE_ROOT, "subpath/runtime.ts");
+
+const STATIC_IMPORT_RE =
+  /^\s*(?:import(?!\s+type)(?:[\s\S]*?\sfrom\s+)?["']([^"']+)["']|export\s+(?!type)(?:\*|\{[^}]*\})\s+from\s+["']([^"']+)["'])/gm;
+
+const resolveRelativeSource = (
+  fromFile: string,
+  specifier: string
+): string | null => {
+  const basePath = resolve(dirname(fromFile), specifier);
+  const candidates = [`${basePath}.ts`, join(basePath, "index.ts")];
+  for (const candidate of candidates) {
+    if (existsSync(candidate)) {
+      return candidate;
+    }
+  }
+  return null;
+};
+
+const collectRuntimeStaticGraph = (): Map<string, string[]> => {
+  const graph = new Map<string, string[]>();
+  const pending = [ENTRYPOINT];
+
+  while (pending.length > 0) {
+    const filePath = pending.pop();
+    if (!filePath || graph.has(filePath)) {
+      continue;
+    }
+
+    const content = readFileSync(filePath, "utf8");
+    const specifiers: string[] = [];
+    for (const match of content.matchAll(STATIC_IMPORT_RE)) {
+      const specifier = match[1] ?? match[2];
+      if (!specifier) {
+        continue;
+      }
+      specifiers.push(specifier);
+      if (specifier.startsWith(".")) {
+        const resolvedPath = resolveRelativeSource(filePath, specifier);
+        if (resolvedPath?.startsWith(SOURCE_ROOT)) {
+          pending.push(resolvedPath);
+        }
+      }
+    }
+
+    graph.set(filePath, specifiers);
+  }
+
+  return graph;
+};
+
+describe("runtime edge import graph", () => {
+  it("does not statically import Node built-ins from the runtime subpath", () => {
+    const graph = collectRuntimeStaticGraph();
+    const offenders = [...graph.entries()].flatMap(([filePath, specifiers]) =>
+      specifiers
+        .filter((specifier) => specifier.startsWith("node:"))
+        .map(
+          (specifier) =>
+            `${filePath.slice(SOURCE_ROOT.length + 1)} -> ${specifier}`
+        )
+    );
+
+    expect(offenders).toEqual([]);
+  });
+});

--- a/packages/harness/src/runtime/runtime-edge-imports.test.ts
+++ b/packages/harness/src/runtime/runtime-edge-imports.test.ts
@@ -1,3 +1,4 @@
+import { execFileSync } from "node:child_process";
 import { existsSync, readFileSync } from "node:fs";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -5,6 +6,7 @@ import { describe, expect, it } from "vitest";
 
 const SOURCE_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "..");
 const ENTRYPOINT = join(SOURCE_ROOT, "subpath/runtime.ts");
+const MINIMAL_AGENT_ROOT = resolve(SOURCE_ROOT, "../../minimal-agent");
 
 const STATIC_IMPORT_RE =
   /^\s*(?:import(?!\s+type)(?:[\s\S]*?\sfrom\s+)?["']([^"']+)["']|export\s+(?!type)(?:\*|\{[^}]*\})\s+from\s+["']([^"']+)["'])/gm;
@@ -68,5 +70,46 @@ describe("runtime edge import graph", () => {
     );
 
     expect(offenders).toEqual([]);
+  });
+
+  it("imports the runtime through browser conditions without process globals", () => {
+    const output = execFileSync(
+      process.execPath,
+      [
+        "--conditions=@ai-sdk-tool/source",
+        "--conditions=browser",
+        "--import",
+        "tsx",
+        "--eval",
+        `
+const originalProcess = globalThis.process;
+Reflect.deleteProperty(globalThis, "process");
+const mod = await import("@ai-sdk-tool/harness/runtime");
+const runtime = await mod.createAgentRuntime({
+  name: "edge-smoke",
+  cwd: "/",
+  agents: [
+    mod.defineAgent({
+      name: "bot",
+      agent: { model: {}, instructions: "hi" },
+    }),
+  ],
+});
+const session = await runtime.openSession();
+await runtime.close();
+globalThis.process = originalProcess;
+if (!session.sessionId.startsWith("edge-smoke-")) {
+  throw new Error(session.sessionId);
+}
+console.log("browser-condition-ok");
+`,
+      ],
+      {
+        cwd: MINIMAL_AGENT_ROOT,
+        encoding: "utf8",
+      }
+    );
+
+    expect(output.trim()).toBe("browser-condition-ok");
   });
 });

--- a/packages/harness/src/runtime/types.ts
+++ b/packages/harness/src/runtime/types.ts
@@ -91,6 +91,7 @@ export interface AgentRuntimeConfig<
 > {
   agents: TAgents;
   context?: TContext;
+  cwd?: string;
   defaultAgent?: TAgents[number]["name"];
   name: string;
   persistence?: AgentRuntimePersistenceConfig;

--- a/packages/harness/src/session.ts
+++ b/packages/harness/src/session.ts
@@ -1,4 +1,4 @@
-import { randomUUID } from "node:crypto";
+import { createRuntimeUUID } from "./uuid";
 
 export class SessionManager {
   private sessionId: string | null = null;
@@ -9,7 +9,7 @@ export class SessionManager {
   }
 
   initialize(): string {
-    this.sessionId = `${this.prefix}-${randomUUID()}`;
+    this.sessionId = `${this.prefix}-${createRuntimeUUID()}`;
     return this.sessionId;
   }
 

--- a/packages/harness/src/uuid.ts
+++ b/packages/harness/src/uuid.ts
@@ -1,0 +1,30 @@
+const getCrypto = (): Crypto | undefined => globalThis.crypto;
+
+export const createRuntimeUUID = (): string => {
+  const crypto = getCrypto();
+
+  if (typeof crypto?.randomUUID === "function") {
+    return crypto.randomUUID();
+  }
+
+  const bytes = new Uint8Array(16);
+  if (typeof crypto?.getRandomValues === "function") {
+    crypto.getRandomValues(bytes);
+  } else {
+    for (let index = 0; index < bytes.length; index += 1) {
+      bytes[index] = Math.floor(Math.random() * 256);
+    }
+  }
+
+  bytes[6] = (bytes[6] % 16) + 64;
+  bytes[8] = (bytes[8] % 64) + 128;
+
+  const hex = Array.from(bytes, (byte) =>
+    byte.toString(16).padStart(2, "0")
+  ).join("");
+
+  return `${hex.slice(0, 8)}-${hex.slice(8, 12)}-${hex.slice(
+    12,
+    16
+  )}-${hex.slice(16, 20)}-${hex.slice(20)}`;
+};

--- a/packages/minimal-agent/index.ts
+++ b/packages/minimal-agent/index.ts
@@ -4,6 +4,7 @@ import {
   formatContextUsage,
   parseCommand,
 } from "@ai-sdk-tool/harness";
+import { loadDotEnvFilesIfAvailable } from "@ai-sdk-tool/harness/env-node";
 import { createTogglePreferenceCommand } from "@ai-sdk-tool/harness/preferences";
 import { createAgentRuntime, defineAgent } from "@ai-sdk-tool/harness/runtime";
 import { runAgentSessionHeadless } from "@ai-sdk-tool/headless/session";
@@ -16,8 +17,11 @@ import {
   Spacer,
   Text,
 } from "@mariozechner/pi-tui";
-import { env } from "./env";
 import { createPreferences, type MinimalAgentPreferences } from "./preferences";
+
+loadDotEnvFilesIfAvailable();
+
+const { env } = await import("./env");
 
 const modelId = env.AI_MODEL;
 const model = createOpenAICompatible({

--- a/packages/minimal-agent/package.json
+++ b/packages/minimal-agent/package.json
@@ -8,7 +8,7 @@
   "scripts": {
     "benchmark": "node --conditions=@ai-sdk-tool/source --import tsx benchmark.ts",
     "build": "tsc && node ../../scripts/fix-esm-imports.mjs dist",
-    "dev": "node --watch --conditions=@ai-sdk-tool/source --import tsx index.ts",
+    "dev": "node --watch --watch-path=index.ts --watch-path=env.ts --watch-path=preferences.ts --conditions=@ai-sdk-tool/source --import tsx index.ts",
     "test": "vitest run",
     "typecheck": "tsc --noEmit"
   },

--- a/packages/tgbot/src/main.ts
+++ b/packages/tgbot/src/main.ts
@@ -1,9 +1,11 @@
 import { setDefaultResultOrder } from "node:dns";
+import { loadDotEnvFilesIfAvailable } from "@ai-sdk-tool/harness/env-node";
 import { Agent, setGlobalDispatcher } from "undici";
 
 setDefaultResultOrder("ipv4first");
 setGlobalDispatcher(new Agent({ connect: { autoSelectFamily: false } }));
 
+loadDotEnvFilesIfAvailable();
 await import("./env");
 const { closeAgent } = await import("./agent");
 const { bot, registerCommands } = await import("./bot");


### PR DESCRIPTION
## Summary

- Keep `@ai-sdk-tool/harness/runtime` free of unconditional Node-only imports so edge consumers do not pull `node:fs`, `node:path`, or `node:crypto` through the runtime subpath.
- Move Node dotenv discovery/loading into the explicit `@ai-sdk-tool/harness/env-node` subpath.
- Load skills and MCP plumbing lazily only when the runtime configuration actually uses those features.
- Preserve Node CLI behavior by calling the Node dotenv loader from minimal-agent and tgbot entrypoints.
- Keep the minimal-agent dev watch fix for the local `EMFILE` failure.
- Add a browser-condition, process-less runtime import/openSession smoke to catch external package conditional-export regressions.

## Root Cause

The first local fix made `minimal-agent` runnable but moved Node filesystem imports into `harness/env.ts`. That broke the existing edge-runtime intent because `createAgentRuntime()` imports runtime internals that should be usable from Cloudflare Workers without probing local `.env` files or statically importing filesystem-backed skills/MCP code.

An Oracle review also found that the harness source graph alone is not enough: the external AI SDK path can resolve to a Node-oriented `@vercel/oidc` build unless browser conditions are active. The new smoke test covers that package-resolution requirement without adding Wrangler as a project dependency.

## Worker-Safe Minimum

The supported minimal edge path is intentionally narrow: import `@ai-sdk-tool/harness/runtime`, pass Worker bindings into the provider directly, call `createAgentRuntime({ cwd: "/" })`, open a session, and run a turn without file persistence, skills, MCP, TUI/headless adapters, or `@ai-sdk-tool/harness/env-node`.

`FileSnapshotStore`, file-backed preferences, local skills discovery, stdio MCP, and Node dotenv loading remain Node-oriented surfaces. A real Cloudflare Worker app still needs its bundler/deploy path to resolve browser conditions correctly; if Cloudflare support becomes a first-class guarantee, add a Wrangler/Workers bundle smoke on top of this package-level test.

## Validation

- `pnpm -F "@ai-sdk-tool/harness" test -- src/runtime/runtime-edge-imports.test.ts`
- `pnpm -F "@ai-sdk-tool/harness" typecheck`
- `pnpm -F "@ai-sdk-tool/harness" test`
- `pnpm -F "@ai-sdk-tool/harness" build`
- `pnpm -F "@plugsuits/minimal-agent" typecheck`
- `pnpm -F "@plugsuits/minimal-agent" test`
- `pnpm -F "@plugsuits/minimal-agent" dev`
- `pnpm -F "@plugsuits/tgbot" typecheck`
- `pnpm -F "@plugsuits/tgbot" test`
- `pnpm run check`
- Runtime import/openSession smoke via the minimal-agent workspace context

## Notes

The new `runtime-edge-imports.test.ts` guards the runtime static import graph against Node built-ins and verifies the external dependency path under browser conditions with `process` removed.
