### PR TITLE
ci: add dedicated edge-safe runtime check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -117,3 +117,29 @@ jobs:
 
       - name: Test
         run: SKIP_E2E=1 pnpm run test
+
+  edge-safe:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10.32.1
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Check edge-safe runtime imports
+        run: pnpm run test:edge-safe

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "typecheck:root": "pnpm -F @ai-sdk-tool/harness exec tsc --noEmit -p ../../tsconfig.root.json",
     "check": "pnpm exec ultracite check .",
     "lint": "pnpm exec ultracite fix .",
+    "test:edge-safe": "pnpm -F @ai-sdk-tool/harness exec vitest run src/runtime/runtime-edge-imports.test.ts",
     "test:headless-edit": "node --import tsx scripts/test-headless-edit-ops.ts",
     "test:headless-edit-edge": "node --import tsx scripts/test-headless-edit-edge-cases.ts",
     "changeset": "changeset",


### PR DESCRIPTION
## Summary

- Add a root `test:edge-safe` script that runs the existing harness runtime edge import guard directly.
- Add a dedicated `edge-safe` CI job so runtime/browser-condition regressions are visible as their own PR check.

## What this checks

- `@ai-sdk-tool/harness/runtime` has no static `node:*` imports in its source graph.
- The runtime subpath imports under browser conditions without a `process` global.

## Verification

- `pnpm run test:edge-safe`
- `pnpm run check`
- `git diff --check`

No changeset: CI-only change.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a dedicated edge-safe runtime CI check to catch Node-only import and browser-condition regressions in `@ai-sdk-tool/harness/runtime`. This makes edge safety a visible, separate PR signal.

- **New Features**
  - Added root `test:edge-safe` script to run the existing import guard test.
  - Added `edge-safe` GitHub Actions job to run the script on PRs, verifying no static `node:*` imports and that runtime subpaths import without a `process` global.

<sup>Written for commit 14c5b57cdc3f36e8b816b9656ad5a21ab8f08fd7. Summary will update on new commits. <a href="https://cubic.dev/pr/minpeter/plugsuits/pull/126?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

