### PR TITLE
chore: add .github/dependabot.yml for automated dependency updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
## What changed

Added `.github/dependabot.yml` with two update configurations:
- **npm** ecosystem targeting `/` — weekly schedule, capped at 5 open PRs
- **github-actions** ecosystem targeting `/` — weekly schedule

## Why

This is an active TypeScript monorepo published to npm with multiple packages and real CI pipelines, but had no Dependabot configuration. GitHub's own security scanner found **7 vulnerabilities** on the default branch (3 high, 2 moderate, 2 low). Without Dependabot, security patches and version bumps require manual tracking. This config ensures they surface automatically as PRs.

## Verification

Ran the `verifyCmd` from the scan plan:

```
cat /Users/minpeter/ultracode-scan/plugsuits/.github/dependabot.yml
```

File exists and contains valid structure (verified with Python string checks):
- `version: 2` present
- `package-ecosystem: "npm"` with weekly interval and `open-pull-requests-limit: 5`
- `package-ecosystem: "github-actions"` with weekly interval

---

This is an automated maintenance pass. No code changes, no lockfile churn — only a config file that enables automated PR creation for dependency updates.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `.github/dependabot.yml` to automate weekly dependency update PRs for `npm` and `github-actions`, limiting `npm` to 5 open PRs. This surfaces security patches and version bumps without manual tracking.

<sup>Written for commit 089a6e744840f54ed075ef37e53a4a63e4d6af1c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/minpeter/plugsuits/pull/130?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

