### PR TITLE
Restore explicit approval requirements for high-risk CEA tools

### DIFF
--- a/packages/cea/src/tools/execute/shell-execute.ts
+++ b/packages/cea/src/tools/execute/shell-execute.ts
@@ -92,6 +92,7 @@ export async function executeCommand(
 
 export const shellExecuteTool = tool({
   description: SHELL_EXECUTE_DESCRIPTION,
+  needsApproval: true,
 
   inputSchema: z.object({
     command: z.string().describe("Shell command to execute"),

--- a/packages/cea/src/tools/execute/shell-interact.ts
+++ b/packages/cea/src/tools/execute/shell-interact.ts
@@ -130,6 +130,7 @@ function hasCtrlC(parsedKeys: string[]): boolean {
 
 export const shellInteractTool = tool({
   description: SHELL_INTERACT_DESCRIPTION,
+  needsApproval: true,
 
   inputSchema: z.object({
     keystrokes: z

--- a/packages/cea/src/tools/modify/delete-file.ts
+++ b/packages/cea/src/tools/modify/delete-file.ts
@@ -95,6 +95,7 @@ export async function executeDeleteFile(
 
 export const deleteFileTool = tool({
   description: DELETE_FILE_DESCRIPTION,
+  needsApproval: true,
   inputSchema,
   execute: (input) => executeDeleteFile(input),
 });

--- a/packages/cea/src/tools/modify/edit-file.ts
+++ b/packages/cea/src/tools/modify/edit-file.ts
@@ -252,6 +252,7 @@ export async function executeEditFile(
 
 export const editFileTool = tool({
   description: EDIT_FILE_DESCRIPTION,
+  needsApproval: true,
   inputSchema,
   execute: (input) => executeEditFile(input),
 });

--- a/packages/cea/src/tools/modify/write-file.ts
+++ b/packages/cea/src/tools/modify/write-file.ts
@@ -56,6 +56,7 @@ export async function executeWriteFile(
 
 export const writeFileTool = tool({
   description: WRITE_FILE_DESCRIPTION,
+  needsApproval: true,
   inputSchema,
   execute: (input) => executeWriteFile(input),
 });

--- a/packages/cea/src/tools/tool-approval.test.ts
+++ b/packages/cea/src/tools/tool-approval.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from "vitest";
+import { shellExecuteTool } from "./execute/shell-execute";
+import { shellInteractTool } from "./execute/shell-interact";
+import { deleteFileTool } from "./modify/delete-file";
+import { editFileTool } from "./modify/edit-file";
+import { writeFileTool } from "./modify/write-file";
+
+describe("high-risk tools", () => {
+  it("require explicit approval before execution", () => {
+    expect(shellExecuteTool.needsApproval).toBe(true);
+    expect(shellInteractTool.needsApproval).toBe(true);
+    expect(writeFileTool.needsApproval).toBe(true);
+    expect(editFileTool.needsApproval).toBe(true);
+    expect(deleteFileTool.needsApproval).toBe(true);
+  });
+});


### PR DESCRIPTION
### Motivation
- A recent change removed the approval gate from high-risk tools that can run shell commands or mutate files, enabling auto-execution and creating a prompt-injection/command-execution vulnerability.

### Description
- Reintroduced `needsApproval: true` on the CEA tool definitions for `shell_execute`, `shell_interact`, `write_file`, `edit_file`, and `delete_file` (files under `packages/cea/src/tools/`).
- Added a focused regression test `packages/cea/src/tools/tool-approval.test.ts` that asserts these tools expose `needsApproval === true` to prevent accidental removal in the future.
- No other behavioral changes were made; tool implementations and safety checks remain unchanged.

### Testing
- Ran the targeted test invocation `pnpm --filter plugsuits exec vitest run src/tools/tool-approval.test.ts src/tools/execute/shell-execute.test.ts src/tools/execute/shell-interact.test.ts src/tools/modify/write-file.test.ts src/tools/modify/edit-file.test.ts src/tools/modify/delete-file.test.ts` and all specified suites passed (6 files, 152 tests passed).
- Ran type-checking with `pnpm --filter plugsuits typecheck` which completed successfully.
- Note: running the package-level `pnpm --filter plugsuits test -- src/tools/execute/shell-interact.test.ts` in this environment invoked the full `src` suite and failed due to unrelated workspace import resolution for `@ai-sdk-tool/harness`, which is not caused by this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d1f95b1fb48327b7ea76fa00c934d0)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores the approval gate for high‑risk CEA tools to prevent auto‑execution of shell and file‑mutation actions. Adds a regression test to ensure these tools always require approval.

- **Bug Fixes**
  - Set `needsApproval: true` on `shell_execute`, `shell_interact`, `write_file`, `edit_file`, and `delete_file`.
  - Added `tool-approval.test.ts` to assert these tools require approval.
  - No changes to tool logic or safety checks.

<sup>Written for commit 59e50a57f06ff67c7c9d594430d506bc4dd3eaf3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/minpeter/plugsuits/pull/139?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

